### PR TITLE
Env fix and tests refactor

### DIFF
--- a/packages/client/src/__tests__/core/wrap-features/env-case.ts
+++ b/packages/client/src/__tests__/core/wrap-features/env-case.ts
@@ -4,13 +4,14 @@ import { PolywrapClient } from "../../../PolywrapClient";
 import { mockPluginRegistration } from "../../helpers";
 import { ClientConfigBuilder } from "@polywrap/client-config-builder-js";
 import { Uri, UriMap } from "@polywrap/core-js";
+import { GetPathToTestWrappers } from "@polywrap/test-cases";
 
 jest.setTimeout(200000);
 
 export const envTestCases = (implementation: string) => {
   describe("invoke with env", () => {
     test(`invoke method without env does not require env in ${implementation}`, async () => {
-      const wrapperPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/00-main/implementations/${implementation}/build`;
+      const wrapperPath = `${GetPathToTestWrappers()}/env-type/00-main/implementations/${implementation}`;
       const wrapperUri = Uri.from(`file/${wrapperPath}`);
 
       const builder = new ClientConfigBuilder();
@@ -31,7 +32,7 @@ export const envTestCases = (implementation: string) => {
     });
 
     test(`invoke method without env works with env in ${implementation}`, async () => {
-      const wrapperPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/00-main/implementations/${implementation}/build`;
+      const wrapperPath = `${GetPathToTestWrappers()}/env-type/00-main/implementations/${implementation}`;
       const wrapperUri = Uri.from(`file/${wrapperPath}`);
 
       const env = {
@@ -70,7 +71,7 @@ export const envTestCases = (implementation: string) => {
     });
 
     test(`invoke method with required env works with env in ${implementation}`, async () => {
-      const wrapperPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/00-main/implementations/${implementation}/build`;
+      const wrapperPath = `${GetPathToTestWrappers()}/env-type/00-main/implementations/${implementation}`;
       const wrapperUri = Uri.from(`file/${wrapperPath}`);
 
       const env = {
@@ -123,7 +124,7 @@ export const envTestCases = (implementation: string) => {
     });
 
     test(`invoke method with required env throws without env registered in ${implementation}`, async () => {
-      const wrapperPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/00-main/implementations/${implementation}/build`;
+      const wrapperPath = `${GetPathToTestWrappers()}/env-type/00-main/implementations/${implementation}`;
       const wrapperUri = Uri.from(`file/${wrapperPath}`);
 
       const builder = new ClientConfigBuilder();
@@ -142,7 +143,7 @@ export const envTestCases = (implementation: string) => {
     });
 
     test(`invoke method with optional env works with env in ${implementation}`, async () => {
-      const wrapperPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/00-main/implementations/${implementation}/build`;
+      const wrapperPath = `${GetPathToTestWrappers()}/env-type/00-main/implementations/${implementation}`;
       const wrapperUri = Uri.from(`file/${wrapperPath}`);
 
       const env = {
@@ -195,7 +196,7 @@ export const envTestCases = (implementation: string) => {
     });
 
     test(`invoke method with optional env works without env in ${implementation}`, async () => {
-      const wrapperPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/00-main/implementations/${implementation}/build`;
+      const wrapperPath = `${GetPathToTestWrappers()}/env-type/00-main/implementations/${implementation}`;
       const wrapperUri = Uri.from(`file/${wrapperPath}`);
 
       const builder = new ClientConfigBuilder();
@@ -214,7 +215,7 @@ export const envTestCases = (implementation: string) => {
     });
 
     test(`env can be registered for any uri in resolution path in ${implementation}`, async () => {
-      const wrapperPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/00-main/implementations/${implementation}/build`;
+      const wrapperPath = `${GetPathToTestWrappers()}/env-type/00-main/implementations/${implementation}`;
       const wrapperUri = Uri.from(`file/${wrapperPath}`);
       const redirectFromUri = Uri.from(`mock/from`);
 
@@ -276,11 +277,8 @@ export const envTestCases = (implementation: string) => {
 
   describe("subinvoke with env", () => {
     test(`subinvoke method without env does not require env in ${implementation}`, async () => {
-      // const subinvokerPath = `${GetPathToTestWrappers()}/env-type/01-subinvoker/implementations/${implementation}`;
-      // const subinvokedPath = `${GetPathToTestWrappers()}/env-type/00-main/implementations/${implementation}`;
-      
-      const subinvokerPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/01-subinvoker/implementations/${implementation}/build`;
-      const subinvokedPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/00-main/implementations/${implementation}/build`;
+      const subinvokerPath = `${GetPathToTestWrappers()}/env-type/01-subinvoker/implementations/${implementation}`;
+      const subinvokedPath = `${GetPathToTestWrappers()}/env-type/00-main/implementations/${implementation}`;
       const { uri: subinvokerUri } = Uri.from(`file/${subinvokerPath}`);
       const { uri: subinvokedUri } = Uri.from(`file/${subinvokedPath}`);
 
@@ -303,8 +301,8 @@ export const envTestCases = (implementation: string) => {
     });
 
     test(`subinvoke method without env works with env in ${implementation}`, async () => {
-      const subinvokerPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/01-subinvoker/implementations/${implementation}/build`;
-      const subinvokedPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/00-main/implementations/${implementation}/build`;
+      const subinvokerPath = `${GetPathToTestWrappers()}/env-type/01-subinvoker/implementations/${implementation}`;
+      const subinvokedPath = `${GetPathToTestWrappers()}/env-type/00-main/implementations/${implementation}`;
       const { uri: subinvokerUri } = Uri.from(`file/${subinvokerPath}`);
       const { uri: subinvokedUri } = Uri.from(`file/${subinvokedPath}`);
     
@@ -344,8 +342,8 @@ export const envTestCases = (implementation: string) => {
     });
 
     test(`subinvoke method with required env works with env in ${implementation}`, async () => {
-      const subinvokerPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/01-subinvoker/implementations/${implementation}/build`;
-      const subinvokedPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/00-main/implementations/${implementation}/build`;
+      const subinvokerPath = `${GetPathToTestWrappers()}/env-type/01-subinvoker/implementations/${implementation}`;
+      const subinvokedPath = `${GetPathToTestWrappers()}/env-type/00-main/implementations/${implementation}`;
       const { uri: subinvokerUri } = Uri.from(`file/${subinvokerPath}`);
       const { uri: subinvokedUri } = Uri.from(`file/${subinvokedPath}`);
 
@@ -399,8 +397,8 @@ export const envTestCases = (implementation: string) => {
     });
 
     test(`subinvoke method with required env throws without env registered in ${implementation}`, async () => {
-      const subinvokerPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/01-subinvoker/implementations/${implementation}/build`;
-      const subinvokedPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/00-main/implementations/${implementation}/build`;
+      const subinvokerPath = `${GetPathToTestWrappers()}/env-type/01-subinvoker/implementations/${implementation}`;
+      const subinvokedPath = `${GetPathToTestWrappers()}/env-type/00-main/implementations/${implementation}`;
       const { uri: subinvokerUri } = Uri.from(`file/${subinvokerPath}`);
       const { uri: subinvokedUri } = Uri.from(`file/${subinvokedPath}`);
 
@@ -420,8 +418,8 @@ export const envTestCases = (implementation: string) => {
     });
 
     test(`subinvoke method with optional env works with env in ${implementation}`, async () => {
-      const subinvokerPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/01-subinvoker/implementations/${implementation}/build`;
-      const subinvokedPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/00-main/implementations/${implementation}/build`;
+      const subinvokerPath = `${GetPathToTestWrappers()}/env-type/01-subinvoker/implementations/${implementation}`;
+      const subinvokedPath = `${GetPathToTestWrappers()}/env-type/00-main/implementations/${implementation}`;
       const { uri: subinvokerUri } = Uri.from(`file/${subinvokerPath}`);
       const { uri: subinvokedUri } = Uri.from(`file/${subinvokedPath}`);
 
@@ -475,8 +473,8 @@ export const envTestCases = (implementation: string) => {
     });
 
     test(`subinvoke method with optional env works without env in ${implementation}`, async () => {
-      const subinvokerPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/01-subinvoker/implementations/${implementation}/build`;
-      const subinvokedPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/00-main/implementations/${implementation}/build`;
+      const subinvokerPath = `${GetPathToTestWrappers()}/env-type/01-subinvoker/implementations/${implementation}`;
+      const subinvokedPath = `${GetPathToTestWrappers()}/env-type/00-main/implementations/${implementation}`;
       const { uri: subinvokerUri } = Uri.from(`file/${subinvokerPath}`);
       const { uri: subinvokedUri } = Uri.from(`file/${subinvokedPath}`);
 
@@ -496,8 +494,8 @@ export const envTestCases = (implementation: string) => {
     });
 
     test(`subinvoker env does not override subinvoked env in ${implementation}`, async () => {
-      const subinvokerPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/01-subinvoker/implementations/${implementation}/build`;
-      const subinvokedPath = `/home/nerfzael/dev/web3api/repos/wrap-test-harness/build/env-type/00-main/implementations/${implementation}/build`;
+      const subinvokerPath = `${GetPathToTestWrappers()}/env-type/02-subinvoker-with-env/implementations/${implementation}`;
+      const subinvokedPath = `${GetPathToTestWrappers()}/env-type/00-main/implementations/${implementation}`;
       const { uri: subinvokerUri } = Uri.from(`file/${subinvokerPath}`);
       const { uri: subinvokedUri } = Uri.from(`file/${subinvokedPath}`);
 

--- a/packages/test-cases/src/index.ts
+++ b/packages/test-cases/src/index.ts
@@ -22,7 +22,7 @@ export async function fetchWrappers(): Promise<void> {
     zip.extractAllTo(destination, /*overwrite*/ true);
   }
 
-  const tag = "0.1.0"
+  const tag = "0.1.1"
   const repoName = "wasm-test-harness"
   const url = `https://github.com/polywrap/${repoName}/releases/download/${tag}/wrappers`;
 

--- a/packages/wasm/src/WasmWrapper.ts
+++ b/packages/wasm/src/WasmWrapper.ts
@@ -164,7 +164,7 @@ export class WasmWrapper implements Wrapper {
             ? args
             : msgpackEncode(args)
           : EMPTY_ENCODED_OBJECT,
-        env: options.env ? msgpackEncode(options.env) : EMPTY_ENCODED_OBJECT,
+        env: options.env ? msgpackEncode(options.env) : new Uint8Array(),
         resolutionContext: options.resolutionContext,
       };
 


### PR DESCRIPTION
- Fixed an issue with optional env
It wasn't working because we were encoding an empty object which displayed an encoded size > 0, so deserialization would fail.

- Implemented a comprehensive test suite for the env feature
- This PR uses test wrappers from the following PR in the wasm test harness: https://github.com/polywrap/wrap-test-harness/pull/64

Test cases:
- invoke method without env does not require env
- invoke method without env works with env
- invoke method with required env works with env
- invoke method with required env throws without env registered
- invoke method with optional env works with env
- invoke method with optional env works without env
- env can be registered for any uri in resolution path
- subinvoke method without env does not require env
- subinvoke method without env works with env
- subinvoke method with required env works with env
- subinvoke method with required env throws without env registered
- subinvoke method with optional env works with env
- subinvoke method with optional env works without env
- subinvoker env does not override subinvoked env