### PR TITLE
Renamed getEnvFromUriHistory and finalUri

### DIFF
--- a/packages/core-client/src/PolywrapCoreClient.ts
+++ b/packages/core-client/src/PolywrapCoreClient.ts
@@ -12,7 +12,7 @@ import {
   IUriResolutionContext,
   UriPackageOrWrapper,
   UriResolutionContext,
-  getEnvFromUriHistory,
+  getEnvFromResolutionPath,
   InvokeResult,
   buildCleanUriHistory,
   CoreClientConfig,
@@ -297,18 +297,18 @@ export class PolywrapCoreClient implements CoreClient {
       resolutionPath =
         resolutionPath.length > 0 ? resolutionPath : [typedOptions.uri];
 
-      const finalUri = resolutionPath[resolutionPath.length - 1];
+      const resolvedUri = resolutionPath[resolutionPath.length - 1];
 
       const wrapper = loadWrapperResult.value;
 
       resolutionContext.trackStep({
         sourceUri: typedOptions.uri,
-        result: UriResolutionResult.ok(finalUri, loadWrapperResult.value),
+        result: UriResolutionResult.ok(resolvedUri, loadWrapperResult.value),
         description: `Client.loadWrapper`,
         subHistory: loadWrapperContext.getHistory(),
       });
 
-      const env = options.env ?? getEnvFromUriHistory(resolutionPath, this);
+      const env = options.env ?? getEnvFromResolutionPath(resolutionPath, this);
 
       const invokeContext = resolutionContext.createSubContext();
 
@@ -320,9 +320,9 @@ export class PolywrapCoreClient implements CoreClient {
       });
 
       resolutionContext.trackStep({
-        sourceUri: finalUri,
+        sourceUri: resolvedUri,
         result: invokeResult.ok
-          ? UriResolutionResult.ok(finalUri)
+          ? UriResolutionResult.ok(resolvedUri)
           : ResultErr(invokeResult.error),
         description: `Client.invokeWrapper`,
         subHistory: invokeContext.getHistory(),

--- a/packages/core/src/utils/getEnvFromResolutionPath.ts
+++ b/packages/core/src/utils/getEnvFromResolutionPath.ts
@@ -1,10 +1,10 @@
 import { Uri, CoreClient, WrapperEnv } from "../types";
 
-export const getEnvFromUriHistory = (
-  uriHistory: Uri[],
+export const getEnvFromResolutionPath = (
+  resolutionPath: Uri[],
   client: CoreClient
 ): Readonly<WrapperEnv> | undefined => {
-  for (const uri of uriHistory) {
+  for (const uri of resolutionPath) {
     const env = client.getEnvByUri(uri);
 
     if (env) {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,4 @@
 export * from "./combinePaths";
-export * from "./getEnvFromUriHistory";
+export * from "./getEnvFromResolutionPath";
 export * from "./is-buffer";
 export * from "./typesHandler";


### PR DESCRIPTION
Renamed `getEnvFromUriHistory` to `getEnvFromResolutionPath` and `finalUri` to `resolvedUri` as both are more appropriate names.