### PR TITLE
fix: add plugin-js as client-config-builder-js dependency

### DIFF
--- a/packages/client-config-builder/package.json
+++ b/packages/client-config-builder/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@polywrap/concurrent-plugin-js": "~0.10.0",
     "@polywrap/core-js": "0.10.1",
+    "@polywrap/plugin-js": "0.10.1",
     "@polywrap/ethereum-provider-js": "npm:@polywrap/ethereum-provider-js@~0.3.1",
     "@polywrap/ethereum-provider-js-v1": "npm:@polywrap/ethereum-provider-js@~0.2.4",
     "@polywrap/file-system-plugin-js": "~0.10.0",


### PR DESCRIPTION
This should fix the following warnings when installing the `@polywrap/client-config-builder-js` package:
<img width="1093" alt="Screenshot 2023-05-22 at 04 09 44" src="https://github.com/polywrap/javascript-client/assets/5522128/3b15e101-6de8-4fa1-a631-f527243c10df">
