### PR TITLE
Increased asyncify data end to match stack size for built wasm modules

### DIFF
--- a/packages/asyncify/src/AsyncWasmInstance.ts
+++ b/packages/asyncify/src/AsyncWasmInstance.ts
@@ -35,7 +35,7 @@ export class AsyncWasmInstance {
 
   private static _dataAddr = 16;
   private static _dataStart = AsyncWasmInstance._dataAddr + 8;
-  private static _dataEnd = 1024;
+  private static _dataEnd = 24576;
 
   private _instance: WasmInstance;
   private _wrappedImports: WasmImports;


### PR DESCRIPTION
Toolchain is building wasm modules with the following stack size:
`ENV ASYNCIFY_STACK_SIZE=24576`
But we don't take advantage of that in our AsyncifyWasmInstance.

Ideally, this should be dynamic, for that I created an issue here: https://github.com/polywrap/javascript-client/issues/49
This fix should prevent any ASYNCIFY_STACK_SIZE errors in the mean time.