### PR TITLE
Chore: Remove missing global fail() function from tests

### DIFF
--- a/packages/client/src/__tests__/core/embedded-package.spec.ts
+++ b/packages/client/src/__tests__/core/embedded-package.spec.ts
@@ -35,10 +35,7 @@ describe("Embedded package", () => {
       },
     });
 
-    if (!result.ok) fail(result.error);
-    expect(result.value).toBeTruthy();
-    expect(typeof result.value).toBe("number");
-    expect(result.value).toEqual(2);
+    expect(result).toStrictEqual(ResultOk(2));
   });
 
   it("can get a file from wrapper", async () => {
@@ -154,9 +151,7 @@ const testEmbeddedPackageWithFile = async (
   const receivedManifestResult = await client.getFile(wrapperUri, {
     path: "wrap.info",
   });
-  if (!receivedManifestResult.ok) fail(receivedManifestResult.error);
-  const receivedManifest = receivedManifestResult.value as Uint8Array;
-  expect(receivedManifest).toEqual(expectedManifest);
+  expect(receivedManifestResult).toEqual(ResultOk(expectedManifest))
 
   const expectedWasmModule = await fs.promises.readFile(
     `${wrapperPath}/wrap.wasm`
@@ -164,16 +159,12 @@ const testEmbeddedPackageWithFile = async (
   const receivedWasmModuleResult = await client.getFile(wrapperUri, {
     path: "wrap.wasm",
   });
-  if (!receivedWasmModuleResult.ok) fail(receivedWasmModuleResult.error);
-  const receivedWasmModule = receivedWasmModuleResult.value as Uint8Array;
-  expect(receivedWasmModule).toEqual(expectedWasmModule);
+  expect(receivedWasmModuleResult).toEqual(ResultOk(expectedWasmModule))
+
 
   const receivedHelloFileResult = await client.getFile(wrapperUri, {
     path: filePath,
     encoding: "utf-8",
   });
-  if (!receivedHelloFileResult.ok) fail(receivedHelloFileResult.error);
-  const receivedHelloFile = receivedHelloFileResult.value as Uint8Array;
-
-  expect(receivedHelloFile).toEqual(fileText);
+  expect(receivedHelloFileResult).toEqual(ResultOk(fileText))
 };

--- a/packages/client/src/__tests__/core/embedded-wrapper.spec.ts
+++ b/packages/client/src/__tests__/core/embedded-wrapper.spec.ts
@@ -14,8 +14,10 @@ const simpleWrapperUri = `fs/${wrapperPath}`;
 
 describe("Embedded wrapper", () => {
   it("can invoke an embedded wrapper", async () => {
-    const manifestBuffer = fs.readFileSync(path.join(wrapperPath, "wrap.info"))
-    const wasmModuleBuffer = fs.readFileSync(path.join(wrapperPath, "wrap.wasm"))
+    const manifestBuffer = fs.readFileSync(path.join(wrapperPath, "wrap.info"));
+    const wasmModuleBuffer = fs.readFileSync(
+      path.join(wrapperPath, "wrap.wasm")
+    );
 
     let wrapper: Wrapper = await WasmWrapper.from(
       manifestBuffer,
@@ -33,19 +35,18 @@ describe("Embedded wrapper", () => {
       method: "add",
       args: {
         a: 1,
-        b: 1
+        b: 1,
       },
     });
 
-    if (!result.ok) fail(result.error);
-    expect(result.value).toBeTruthy();
-    expect(typeof result.value).toBe("number");
-    expect(result.value).toEqual(2);
+    expect(result).toStrictEqual(ResultOk(2));
   });
 
   it("can get a file from wrapper", async () => {
-    const manifestBuffer = fs.readFileSync(path.join(wrapperPath, "wrap.info"))
-    const wasmModuleBuffer = fs.readFileSync(path.join(wrapperPath, "wrap.wasm"))
+    const manifestBuffer = fs.readFileSync(path.join(wrapperPath, "wrap.info"));
+    const wasmModuleBuffer = fs.readFileSync(
+      path.join(wrapperPath, "wrap.wasm")
+    );
     const testFilePath = "hello.txt";
     const testFileText = "Hello Test!";
 
@@ -63,8 +64,10 @@ describe("Embedded wrapper", () => {
   });
 
   it("can add embedded wrapper through file reader", async () => {
-    const manifestBuffer = fs.readFileSync(path.join(wrapperPath, "wrap.info"))
-    const wasmModuleBuffer = fs.readFileSync(path.join(wrapperPath, "wrap.wasm"))
+    const manifestBuffer = fs.readFileSync(path.join(wrapperPath, "wrap.info"));
+    const wasmModuleBuffer = fs.readFileSync(
+      path.join(wrapperPath, "wrap.wasm")
+    );
     const testFilePath = "hello.txt";
     const testFileText = "Hello Test!";
 
@@ -86,8 +89,10 @@ describe("Embedded wrapper", () => {
   });
 
   it("can add embedded wrapper with async wrap manifest", async () => {
-    const manifestBuffer = fs.readFileSync(path.join(wrapperPath, "wrap.info"))
-    const wasmModuleBuffer = fs.readFileSync(path.join(wrapperPath, "wrap.wasm"))
+    const manifestBuffer = fs.readFileSync(path.join(wrapperPath, "wrap.info"));
+    const wasmModuleBuffer = fs.readFileSync(
+      path.join(wrapperPath, "wrap.wasm")
+    );
     const testFilePath = "hello.txt";
     const testFileText = "Hello Test!";
 
@@ -109,8 +114,10 @@ describe("Embedded wrapper", () => {
   });
 
   it("can add embedded wrapper with async wasm module", async () => {
-    const manifestBuffer = fs.readFileSync(path.join(wrapperPath, "wrap.info"))
-    const wasmModuleBuffer = fs.readFileSync(path.join(wrapperPath, "wrap.wasm"))
+    const manifestBuffer = fs.readFileSync(path.join(wrapperPath, "wrap.info"));
+    const wasmModuleBuffer = fs.readFileSync(
+      path.join(wrapperPath, "wrap.wasm")
+    );
     const testFilePath = "hello.txt";
     const testFileText = "Hello Test!";
 
@@ -148,25 +155,19 @@ const testEmbeddedWrapperWithFile = async (
   const receivedManifestResult = await client.getFile(simpleWrapperUri, {
     path: "wrap.info",
   });
-  if (!receivedManifestResult.ok) fail(receivedManifestResult.error);
-  const receivedManifest = receivedManifestResult.value as Uint8Array;
-  expect(receivedManifest).toEqual(expectedManifest);
+  expect(receivedManifestResult).toEqual(ResultOk(expectedManifest));
 
-  const expectedWasmModule = 
-    await fs.promises.readFile(`${wrapperPath}/wrap.wasm`);
+  const expectedWasmModule = await fs.promises.readFile(
+    `${wrapperPath}/wrap.wasm`
+  );
   const receivedWasmModuleResult = await client.getFile(simpleWrapperUri, {
     path: "wrap.wasm",
   });
-  if (!receivedWasmModuleResult.ok) fail(receivedWasmModuleResult.error);
-  const receivedWasmModule = receivedWasmModuleResult.value as Uint8Array;
-  expect(receivedWasmModule).toEqual(expectedWasmModule);
+  expect(receivedWasmModuleResult).toEqual(ResultOk(expectedWasmModule));
 
   const receivedHelloFileResult = await client.getFile(simpleWrapperUri, {
     path: filePath,
     encoding: "utf-8",
   });
-  if (!receivedHelloFileResult.ok) fail(receivedHelloFileResult.error);
-  const receivedHelloFile = receivedHelloFileResult.value as Uint8Array;
-
-  expect(receivedHelloFile).toEqual(fileText);
+  expect(receivedHelloFileResult).toEqual(ResultOk(fileText));
 };

--- a/packages/client/src/__tests__/core/plugin-wrapper.spec.ts
+++ b/packages/client/src/__tests__/core/plugin-wrapper.spec.ts
@@ -3,7 +3,8 @@ import { IWrapPackage, Uri } from "@polywrap/core-js";
 import { WrapManifest } from "@polywrap/wrap-manifest-types-js";
 import { PluginPackage, PluginModule } from "@polywrap/plugin-js";
 import { UriResolver } from "@polywrap/uri-resolvers-js";
-import * as SysBundle from "@polywrap/sys-config-bundle-js"
+import * as SysBundle from "@polywrap/sys-config-bundle-js";
+import { ResultOk } from "@polywrap/result";
 
 jest.setTimeout(200000);
 
@@ -40,26 +41,21 @@ describe("plugin-wrapper", () => {
   test("plugin map types", async () => {
     const implementationUri = Uri.from("wrap://ens/some-implementation.eth");
     const mockPlugin = mockMapPlugin();
-    const client = new PolywrapClient(
-      {
-        resolver: UriResolver.from([
-          {
-            uri: implementationUri,
-            package: mockPlugin,
-          },
-        ]),
-      }
-    );
+    const client = new PolywrapClient({
+      resolver: UriResolver.from([
+        {
+          uri: implementationUri,
+          package: mockPlugin,
+        },
+      ]),
+    });
 
     const getResult = await client.invoke({
       uri: implementationUri,
       method: "getMap",
     });
-
-    if (!getResult.ok) fail(getResult.error);
-    expect(getResult.value).toBeTruthy();
-    expect(getResult.value).toMatchObject(
-      new Map<string, number>().set("a", 1).set("b", 2)
+    expect(getResult).toStrictEqual(
+      ResultOk(new Map<string, number>().set("a", 1).set("b", 2))
     );
 
     const updateResult = await client.invoke({
@@ -69,28 +65,23 @@ describe("plugin-wrapper", () => {
         map: new Map<string, number>().set("b", 1).set("c", 5),
       },
     });
-
-    if (!updateResult.ok) fail(updateResult.error);
-    expect(updateResult.value).toBeTruthy();
-    expect(updateResult.value).toMatchObject(
-      new Map<string, number>().set("a", 1).set("b", 3).set("c", 5)
+    expect(updateResult).toStrictEqual(
+      ResultOk(new Map<string, number>().set("a", 1).set("b", 3).set("c", 5))
     );
   });
 
   test("get manifest should fetch wrap manifest from plugin", async () => {
-    const client = new PolywrapClient(
-      {
-        resolver: UriResolver.from([
-          {
-            uri: Uri.from(SysBundle.bundle.http.uri),
-            package: SysBundle.bundle.http.package as IWrapPackage
-          },
-        ]),
-      }
+    const client = new PolywrapClient({
+      resolver: UriResolver.from([
+        {
+          uri: Uri.from(SysBundle.bundle.http.uri),
+          package: SysBundle.bundle.http.package as IWrapPackage,
+        },
+      ]),
+    });
+    const manifestResult = await client.getManifest(SysBundle.bundle.http.uri);
+    expect(manifestResult).toMatchObject(
+      ResultOk({ type: "plugin", name: "Http" })
     );
-    const manifest = await client.getManifest(SysBundle.bundle.http.uri);
-    if (!manifest.ok) fail(manifest.error);
-    expect(manifest.value.type).toEqual("plugin");
-    expect(manifest.value.name).toEqual("Http");
   });
 });

--- a/packages/client/src/__tests__/core/type-test-cases.ts
+++ b/packages/client/src/__tests__/core/type-test-cases.ts
@@ -4,6 +4,7 @@ import { PolywrapClient } from "../../PolywrapClient";
 import BigNumber from "bignumber.js";
 import { PolywrapClientConfigBuilder } from "@polywrap/client-config-builder-js";
 import { GetPathToTestWrappers } from "@polywrap/test-cases";
+import { ResultOk } from "@polywrap/result";
 
 export const typeTestCases = (implementation: string) => {
   describe("types test cases", () => {
@@ -18,7 +19,7 @@ export const typeTestCases = (implementation: string) => {
       const client = new PolywrapClient(config);
 
       const uri = `fs/${GetPathToTestWrappers()}/asyncify/implementations/${implementation}`;
-      const subsequentInvokes = await client.invoke({
+      const subsequentInvokesResult = await client.invoke({
         uri: uri,
         method: "subsequentInvokes",
         args: {
@@ -29,43 +30,31 @@ export const typeTestCases = (implementation: string) => {
       const expected = Array.from(new Array(40), (_, index) =>
         index.toString()
       );
+      expect(subsequentInvokesResult).toEqual(ResultOk(expected));
 
-      if (!subsequentInvokes.ok) fail(subsequentInvokes.error);
-      expect(subsequentInvokes.value).toBeTruthy();
-      expect(subsequentInvokes.value).toEqual(expected);
-
-      const localVarMethod = await client.invoke<boolean>({
+      const localVarMethodResult = await client.invoke<boolean>({
         uri,
         method: "localVarMethod",
       });
+      expect(localVarMethodResult).toEqual(ResultOk(true));
 
-      if (!localVarMethod.ok) fail(localVarMethod.error);
-      expect(localVarMethod.value).toBeTruthy();
-      expect(localVarMethod.value).toEqual(true);
-
-      const globalVarMethod = await client.invoke<boolean>({
+      const globalVarMethodResult = await client.invoke<boolean>({
         uri,
         method: "globalVarMethod",
       });
-
-      if (!globalVarMethod.ok) fail(globalVarMethod.error);
-      expect(globalVarMethod.value).toBeTruthy();
-      expect(globalVarMethod.value).toEqual(true);
+      expect(globalVarMethodResult).toEqual(ResultOk(true));
 
       const largeStr = new Array(10000).join("polywrap ");
-      const setDataWithLargeArgs = await client.invoke<string>({
+      const setDataWithLargeArgsResult = await client.invoke<string>({
         uri,
         method: "setDataWithLargeArgs",
         args: {
           value: largeStr,
         },
       });
+      expect(setDataWithLargeArgsResult).toEqual(ResultOk(largeStr));
 
-      if (!setDataWithLargeArgs.ok) fail(setDataWithLargeArgs.error);
-      expect(setDataWithLargeArgs.value).toBeTruthy();
-      expect(setDataWithLargeArgs.value).toEqual(largeStr);
-
-      const setDataWithManyArgs = await client.invoke<string>({
+      const setDataWithManyArgsResult = await client.invoke<string>({
         uri,
         method: "setDataWithManyArgs",
         args: {
@@ -83,11 +72,10 @@ export const typeTestCases = (implementation: string) => {
           valueL: "polywrap l",
         },
       });
-
-      if (!setDataWithManyArgs.ok) fail(setDataWithManyArgs.error);
-      expect(setDataWithManyArgs.value).toBeTruthy();
-      expect(setDataWithManyArgs.value).toEqual(
-        "polywrap apolywrap bpolywrap cpolywrap dpolywrap epolywrap fpolywrap gpolywrap hpolywrap ipolywrap jpolywrap kpolywrap l"
+      expect(setDataWithManyArgsResult).toEqual(
+        ResultOk(
+          "polywrap apolywrap bpolywrap cpolywrap dpolywrap epolywrap fpolywrap gpolywrap hpolywrap ipolywrap jpolywrap kpolywrap l"
+        )
       );
 
       const createObj = (i: number) => {
@@ -107,7 +95,7 @@ export const typeTestCases = (implementation: string) => {
         };
       };
 
-      const setDataWithManyStructuredArgs = await client.invoke<string>({
+      const setDataWithManyStructuredArgsResult = await client.invoke<string>({
         uri,
         method: "setDataWithManyStructuredArgs",
         args: {
@@ -125,11 +113,7 @@ export const typeTestCases = (implementation: string) => {
           valueL: createObj(12),
         },
       });
-
-      if (!setDataWithManyStructuredArgs.ok)
-        fail(setDataWithManyStructuredArgs.error);
-      expect(setDataWithManyStructuredArgs.value).toBeTruthy();
-      expect(setDataWithManyStructuredArgs.value).toBe(true);
+      expect(setDataWithManyStructuredArgsResult).toEqual(ResultOk(true));
     });
 
     test(`bigint-type ${implementation}`, async () => {
@@ -146,9 +130,7 @@ export const typeTestCases = (implementation: string) => {
         },
       });
       let result = BigInt("123456789123456789") * BigInt("987654321987654321");
-      if (!response.ok) fail(response.error);
-      expect(response.value).toBeTruthy();
-      expect(response.value).toEqual(result.toString());
+      expect(response).toEqual(ResultOk(result.toString()));
 
       response = await client.invoke({
         uri,
@@ -169,9 +151,7 @@ export const typeTestCases = (implementation: string) => {
         BigInt("987654321987654321") *
         BigInt("987654321987654321987654321987654321");
 
-      if (!response.ok) fail(response.error);
-      expect(response.value).toBeTruthy();
-      expect(response.value).toEqual(result.toString());
+      expect(response).toEqual(ResultOk(result.toString()));
     });
 
     test(`bignumber-type ${implementation}`, async () => {
@@ -192,9 +172,7 @@ export const typeTestCases = (implementation: string) => {
       let prop1 = new BigNumber("98.7654321987654321");
       let result = arg1.times(prop1);
 
-      if (!response.ok) fail(response.error);
-      expect(response.value).toBeTruthy();
-      expect(response.value).toEqual(result.toFixed());
+      expect(response).toEqual(ResultOk(result.toFixed()));
 
       response = await client.invoke({
         uri,
@@ -215,9 +193,7 @@ export const typeTestCases = (implementation: string) => {
       const prop2 = new BigNumber("987.654321987654321987654321987654321");
       result = arg1.times(arg2).times(prop1).times(prop2);
 
-      if (!response.ok) fail(response.error);
-      expect(response.value).toBeTruthy();
-      expect(response.value).toEqual(result.toFixed());
+      expect(response).toEqual(ResultOk(result.toFixed()));
     });
 
     test(`bytes-type ${implementation}`, async () => {
@@ -233,10 +209,8 @@ export const typeTestCases = (implementation: string) => {
         },
       });
 
-      if (!response.ok) fail(response.error);
-      expect(response.value).toBeTruthy();
-      expect(response.value).toEqual(
-        new TextEncoder().encode("Argument Value Sanity!")
+      expect(response).toEqual(
+        ResultOk(new TextEncoder().encode("Argument Value Sanity!"))
       );
     });
 
@@ -267,9 +241,7 @@ export const typeTestCases = (implementation: string) => {
         },
       });
 
-      if (!method1b.ok) fail(method1b.error);
-      expect(method1b.value).toBeTruthy();
-      expect(method1b.value).toEqual(2);
+      expect(method1b).toEqual(ResultOk(2));
 
       let method1c = await client.invoke({
         uri,
@@ -294,9 +266,7 @@ export const typeTestCases = (implementation: string) => {
         },
       });
 
-      if (!method2a.ok) fail(method2a.error);
-      expect(method2a.value).toBeTruthy();
-      expect(method2a.value).toEqual([0, 0, 2]);
+      expect(method2a).toEqual(ResultOk([0, 0, 2]));
     });
 
     test(`invalid-types ${implementation}`, async () => {
@@ -385,8 +355,7 @@ export const typeTestCases = (implementation: string) => {
         },
       });
 
-      if (!parseResponse.ok) fail(parseResponse.error);
-      expect(parseResponse.value).toEqual(value);
+      expect(parseResponse).toEqual(ResultOk(value));
 
       const values = [
         JSON.stringify({ bar: "foo" }),
@@ -401,8 +370,7 @@ export const typeTestCases = (implementation: string) => {
         },
       });
 
-      if (!stringifyResponse.ok) fail(stringifyResponse.error);
-      expect(stringifyResponse.value).toEqual(values.join(""));
+      expect(stringifyResponse).toEqual(ResultOk(values.join("")));
 
       const object = {
         jsonA: JSON.stringify({ foo: "bar" }),
@@ -417,9 +385,8 @@ export const typeTestCases = (implementation: string) => {
         },
       });
 
-      if (!stringifyObjectResponse.ok) fail(stringifyObjectResponse.error);
-      expect(stringifyObjectResponse.value).toEqual(
-        object.jsonA + object.jsonB
+      expect(stringifyObjectResponse).toEqual(
+        ResultOk(object.jsonA + object.jsonB)
       );
 
       const json = {
@@ -434,9 +401,8 @@ export const typeTestCases = (implementation: string) => {
         args: json,
       });
 
-      if (!methodJSONResponse.ok) fail(methodJSONResponse.error);
       const methodJSONResult = JSON.stringify(json);
-      expect(methodJSONResponse.value).toEqual(methodJSONResult);
+      expect(methodJSONResponse).toEqual(ResultOk(methodJSONResult));
 
       // @TODO: Remove this once https://github.com/polywrap/toolchain/issues/633 is implemented & tested
       if (implementation === "rs") {
@@ -452,8 +418,7 @@ export const typeTestCases = (implementation: string) => {
           },
         });
 
-        if (!parseReservedResponse.ok) fail(parseReservedResponse.error);
-        expect(parseReservedResponse.value).toEqual(reserved);
+        expect(parseReservedResponse).toEqual(ResultOk(reserved));
 
         const stringifyReservedResponse = await client.invoke<string>({
           uri,
@@ -463,10 +428,8 @@ export const typeTestCases = (implementation: string) => {
           },
         });
 
-        if (!stringifyReservedResponse.ok)
-          fail(stringifyReservedResponse.error);
-        expect(stringifyReservedResponse.value).toEqual(
-          JSON.stringify(reserved)
+        expect(stringifyReservedResponse).toEqual(
+          ResultOk(JSON.stringify(reserved))
         );
       }
     });
@@ -576,22 +539,22 @@ export const typeTestCases = (implementation: string) => {
         },
       });
 
-      if (!method1a.ok) fail(method1a.error);
-      expect(method1a.value).toBeTruthy();
-      expect(method1a.value).toEqual([
-        {
-          prop: "arg1 prop",
-          nested: {
-            prop: "arg1 nested prop",
+      expect(method1a).toEqual(
+        ResultOk([
+          {
+            prop: "arg1 prop",
+            nested: {
+              prop: "arg1 nested prop",
+            },
           },
-        },
-        {
-          prop: "",
-          nested: {
+          {
             prop: "",
+            nested: {
+              prop: "",
+            },
           },
-        },
-      ]);
+        ])
+      );
 
       const method1b = await client.invoke({
         uri,
@@ -612,22 +575,22 @@ export const typeTestCases = (implementation: string) => {
         },
       });
 
-      if (!method1b.ok) fail(method1b.error);
-      expect(method1b.value).toBeTruthy();
-      expect(method1b.value).toEqual([
-        {
-          prop: "arg1 prop",
-          nested: {
-            prop: "arg1 nested prop",
+      expect(method1b).toEqual(
+        ResultOk([
+          {
+            prop: "arg1 prop",
+            nested: {
+              prop: "arg1 nested prop",
+            },
           },
-        },
-        {
-          prop: "arg2 prop",
-          nested: {
-            prop: "arg2 circular prop",
+          {
+            prop: "arg2 prop",
+            nested: {
+              prop: "arg2 circular prop",
+            },
           },
-        },
-      ]);
+        ])
+      );
 
       const method2a = await client.invoke({
         uri,
@@ -642,14 +605,14 @@ export const typeTestCases = (implementation: string) => {
         },
       });
 
-      if (!method2a.ok) fail(method2a.error);
-      expect(method2a.value).toBeTruthy();
-      expect(method2a.value).toEqual({
-        prop: "arg prop",
-        nested: {
-          prop: "arg nested prop",
-        },
-      });
+      expect(method2a).toEqual(
+        ResultOk({
+          prop: "arg prop",
+          nested: {
+            prop: "arg nested prop",
+          },
+        })
+      );
 
       const method2b = await client.invoke({
         uri,
@@ -664,8 +627,7 @@ export const typeTestCases = (implementation: string) => {
         },
       });
 
-      if (!method2b.ok) fail(method2b.error);
-      expect(method2b.value).toEqual(null);
+      expect(method2b).toEqual(ResultOk(null));
 
       const method3 = await client.invoke({
         uri,
@@ -680,17 +642,17 @@ export const typeTestCases = (implementation: string) => {
         },
       });
 
-      if (!method3.ok) fail(method3.error);
-      expect(method3.value).toBeTruthy();
-      expect(method3.value).toEqual([
-        null,
-        {
-          prop: "arg prop",
-          nested: {
-            prop: "arg nested prop",
+      expect(method3).toEqual(
+        ResultOk([
+          null,
+          {
+            prop: "arg prop",
+            nested: {
+              prop: "arg nested prop",
+            },
           },
-        },
-      ]);
+        ])
+      );
 
       const method4 = await client.invoke({
         uri,
@@ -702,14 +664,14 @@ export const typeTestCases = (implementation: string) => {
         },
       });
 
-      if (!method4.ok) fail(method4.error);
-      expect(method4.value).toBeTruthy();
-      expect(method4.value).toEqual({
-        prop: "1234",
-        nested: {
-          prop: "nested prop",
-        },
-      });
+      expect(method4).toEqual(
+        ResultOk({
+          prop: "1234",
+          nested: {
+            prop: "nested prop",
+          },
+        })
+      );
     });
 
     test(`map-type ${implementation}`, async () => {
@@ -737,8 +699,7 @@ export const typeTestCases = (implementation: string) => {
           map: mapClass,
         },
       });
-      if (!returnMapResponse1.ok) fail(returnMapResponse1.error);
-      expect(returnMapResponse1.value).toEqual(mapClass);
+      expect(returnMapResponse1).toEqual(ResultOk(mapClass));
 
       const returnMapResponse2 = await client.invoke<Map<string, number>>({
         uri,
@@ -747,8 +708,7 @@ export const typeTestCases = (implementation: string) => {
           map: mapRecord,
         },
       });
-      if (!returnMapResponse2.ok) fail(returnMapResponse2.error);
-      expect(returnMapResponse2.value).toEqual(mapClass);
+      expect(returnMapResponse2).toEqual(ResultOk(mapClass));
 
       const getKeyResponse1 = await client.invoke<number>({
         uri,
@@ -761,8 +721,7 @@ export const typeTestCases = (implementation: string) => {
           key: "Hello",
         },
       });
-      if (!getKeyResponse1.ok) fail(getKeyResponse1.error);
-      expect(getKeyResponse1.value).toEqual(mapClass.get("Hello"));
+      expect(getKeyResponse1).toEqual(ResultOk(mapClass.get("Hello")));
 
       const getKeyResponse2 = await client.invoke<number>({
         uri,
@@ -775,8 +734,7 @@ export const typeTestCases = (implementation: string) => {
           key: "Heyo",
         },
       });
-      if (!getKeyResponse2.ok) fail(getKeyResponse2.error);
-      expect(getKeyResponse2.value).toEqual(mapRecord.Heyo);
+      expect(getKeyResponse2).toEqual(ResultOk(mapRecord.Heyo));
 
       const returnCustomMap = await client.invoke<{
         map: Map<string, number>;
@@ -791,11 +749,12 @@ export const typeTestCases = (implementation: string) => {
           },
         },
       });
-      if (!returnCustomMap.ok) fail(returnCustomMap.error);
-      expect(returnCustomMap.value).toEqual({
-        map: mapClass,
-        nestedMap: nestedMapClass,
-      });
+      expect(returnCustomMap).toEqual(
+        ResultOk({
+          map: mapClass,
+          nestedMap: nestedMapClass,
+        })
+      );
 
       const returnNestedMap = await client.invoke<
         Map<string, Map<string, number>>
@@ -806,8 +765,7 @@ export const typeTestCases = (implementation: string) => {
           foo: nestedMapClass,
         },
       });
-      if (!returnNestedMap.ok) fail(returnNestedMap.error);
-      expect(returnNestedMap.value).toEqual(nestedMapClass);
+      expect(returnNestedMap).toEqual(ResultOk(nestedMapClass));
     });
   });
 };

--- a/packages/client/src/__tests__/core/wasm-wrapper.spec.ts
+++ b/packages/client/src/__tests__/core/wasm-wrapper.spec.ts
@@ -1,4 +1,4 @@
-import { msgpackDecode } from "@polywrap/msgpack-js";
+import { msgpackEncode } from "@polywrap/msgpack-js";
 import { GetPathToTestWrappers } from "@polywrap/test-cases";
 import fs from "fs";
 import { Uri, PolywrapClient, IWrapPackage } from "../..";
@@ -7,6 +7,7 @@ import { PluginModule, PluginPackage } from "@polywrap/plugin-js";
 import { UriResolver } from "@polywrap/uri-resolvers-js";
 import { PolywrapClientConfigBuilder } from "@polywrap/client-config-builder-js";
 import { mockPluginRegistration, ErrResult } from "../helpers";
+import { ResultOk } from "@polywrap/result";
 
 jest.setTimeout(200000);
 
@@ -34,11 +35,7 @@ describe("wasm-wrapper", () => {
         b: 1
       },
     });
-
-    if (!result.ok) fail(result.error);
-    expect(result.value).toBeTruthy();
-    expect(typeof result.value).toBe("number");
-    expect(result.value).toEqual(2);
+    expect(result).toStrictEqual(ResultOk(2));
   });
 
   test("can invoke with typed URI", async () => {
@@ -52,10 +49,7 @@ describe("wasm-wrapper", () => {
       },
     });
 
-    if (!result.ok) fail(result.error);
-    expect(result.value).toBeTruthy();
-    expect(typeof result.value).toBe("number");
-    expect(result.value).toEqual(2);
+    expect(result).toStrictEqual(ResultOk(2));
   });
 
   test("invoke with decode defaulted to true works as expected", async () => {
@@ -69,10 +63,7 @@ describe("wasm-wrapper", () => {
       },
     });
 
-    if (!result.ok) fail(result.error);
-    expect(result.value).toBeTruthy();
-    expect(typeof result.value).toBe("number");
-    expect(result.value).toEqual(2);
+    expect(result).toStrictEqual(ResultOk(2));
   });
 
   test("invoke with decode set to false works as expected", async () => {
@@ -87,10 +78,7 @@ describe("wasm-wrapper", () => {
       encodeResult: true,
     });
 
-    if (!result.ok) fail(result.error);
-    expect(result.value).toBeTruthy();
-    expect(result.value instanceof Uint8Array).toBeTruthy();
-    expect(msgpackDecode(result.value as Uint8Array)).toEqual(2);
+    expect(result).toEqual(ResultOk(msgpackEncode(2)));
   });
 
   it("should invoke wrapper with custom redirects", async () => {
@@ -110,9 +98,7 @@ describe("wasm-wrapper", () => {
       },
     });
 
-    if (!result.ok) fail(result.error);
-    expect(result.value).toBeTruthy();
-    expect(result.value).toEqual("plugin response");
+    expect(result).toEqual(ResultOk("plugin response"));
   });
 
   it("should allow clone + reconfigure of redirects", async () => {
@@ -133,9 +119,7 @@ describe("wasm-wrapper", () => {
       },
     });
 
-    if (!clientResult.ok) fail(clientResult.error);
-    expect(clientResult.value).toBeTruthy();
-    expect(clientResult.value).toEqual(2);
+    expect(clientResult).toEqual(ResultOk(2));
 
     const redirects = {
       [wrapperUri.uri]: "wrap://ens/mock.polywrap.eth",
@@ -154,9 +138,7 @@ describe("wasm-wrapper", () => {
       },
     });
 
-    if (!newClientResult.ok) fail(newClientResult.error);
-    expect(newClientResult.value).toBeTruthy();
-    expect(newClientResult.value).toEqual("plugin response");
+    expect(newClientResult).toEqual(ResultOk("plugin response"));
   });
 
   test("get file from wrapper", async () => {
@@ -169,10 +151,7 @@ describe("wasm-wrapper", () => {
     const receivedManifestResult = await client.getFile(wrapperUri, {
       path: "./wrap.info",
     });
-    if (!receivedManifestResult.ok) fail(receivedManifestResult.error);
-    const receivedManifest = receivedManifestResult.value as Uint8Array;
-
-    expect(receivedManifest).toEqual(expectedManifest);
+    expect(receivedManifestResult).toEqual(ResultOk(expectedManifest));
 
     const expectedWasmModule = new Uint8Array(
       await fs.promises.readFile(`${wrapperPath}/wrap.wasm`)
@@ -181,10 +160,7 @@ describe("wasm-wrapper", () => {
     const receivedWasmModuleResult = await client.getFile(wrapperUri, {
       path: "./wrap.wasm",
     });
-    if (!receivedWasmModuleResult.ok) fail(receivedWasmModuleResult.error);
-    const receivedWasmModule = receivedWasmModuleResult.value as Uint8Array;
-
-    expect(receivedWasmModule).toEqual(expectedWasmModule);
+    expect(receivedWasmModuleResult).toEqual(ResultOk(expectedWasmModule));
 
     const pluginClient = new PolywrapClient({
       resolver: UriResolver.from([

--- a/packages/client/src/__tests__/core/wrap-features/interface-implementation-case.ts
+++ b/packages/client/src/__tests__/core/wrap-features/interface-implementation-case.ts
@@ -8,6 +8,7 @@ import { PolywrapClientConfigBuilder } from "@polywrap/client-config-builder-js"
 import { UriResolver } from "@polywrap/uri-resolvers-js";
 import { mockPluginRegistration } from "../../helpers";
 import { GetPathToTestWrappers } from "@polywrap/test-cases";
+import { ResultOk } from "@polywrap/result";
 
 jest.setTimeout(200000);
 
@@ -38,12 +39,10 @@ export const interfaceInvokeCase = (implementation: string) => {
         },
       });
 
-      if (!result.ok) fail(result.error);
-      expect(result.value).toBeTruthy();
-      expect(result.value).toEqual({
+      expect(result).toEqual(ResultOk({
         uint8: 1,
         str: "Test String 1",
-      });
+      }));
     });
   });
 
@@ -77,11 +76,10 @@ export const interfaceInvokeCase = (implementation: string) => {
         applyResolution: false,
       });
 
-      if (!implementations.ok) fail(implementations.error);
-      expect(implementations.value).toEqual([
+      expect(implementations).toEqual(ResultOk([
         implementation1Uri,
         implementation2Uri,
-      ]);
+      ]));
     });
 
     it("should get all implementations of interface", async () => {
@@ -133,25 +131,22 @@ export const interfaceInvokeCase = (implementation: string) => {
         applyResolution: true,
       });
 
-      if (!implementations1.ok) fail(implementations1.error);
-      expect(implementations1.value).toEqual([
+      expect(implementations1).toEqual(ResultOk([
         implementation1Uri,
         implementation2Uri,
         implementation3Uri,
-      ]);
+      ]));
 
-      if (!implementations2.ok) fail(implementations2.error);
-      expect(implementations2.value).toEqual([
+      expect(implementations2).toEqual(ResultOk([
         implementation1Uri,
         implementation2Uri,
         implementation3Uri,
-      ]);
+      ]));
 
-      if (!implementations3.ok) fail(implementations3.error);
-      expect(implementations3.value).toEqual([
+      expect(implementations3).toEqual(ResultOk([
         implementation3Uri,
         implementation4Uri,
-      ]);
+      ]));
     });
 
     it("should merge user-defined interface implementations with each other", async () => {
@@ -225,8 +220,7 @@ export const interfaceInvokeCase = (implementation: string) => {
         { applyResolution: true }
       );
 
-      if (!getImplementationsResult.ok) fail(getImplementationsResult.error);
-      expect(getImplementationsResult.value).toEqual([implementation2Uri]);
+      expect(getImplementationsResult).toEqual(ResultOk([implementation2Uri]));
     });
 
     test("get implementations - return implementations for plugins which don't have interface stated in manifest", async () => {
@@ -253,11 +247,10 @@ export const interfaceInvokeCase = (implementation: string) => {
         { applyResolution: true }
       );
 
-      if (!getImplementationsResult.ok) fail(getImplementationsResult.error);
-      expect(getImplementationsResult.value).toEqual([
+      expect(getImplementationsResult).toEqual(ResultOk([
         implementation1Uri,
         implementation2Uri,
-      ]);
+      ]));
     });
 
     test("getImplementations - pass string or Uri", async () => {
@@ -283,26 +276,22 @@ export const interfaceInvokeCase = (implementation: string) => {
       let result = await client.getImplementations(oldInterfaceUri, {
         applyResolution: false,
       });
-      if (!result.ok) fail(result.error);
-      expect(result.value).toEqual([implementation1Uri]);
+      expect(result).toEqual(ResultOk([implementation1Uri]));
 
       result = await client.getImplementations(oldInterfaceUri, {
         applyResolution: true,
       });
-      if (!result.ok) fail(result.error);
-      expect(result.value).toEqual([implementation1Uri, implementation2Uri]);
+      expect(result).toEqual(ResultOk([implementation1Uri, implementation2Uri]));
 
       let result2 = await client.getImplementations(oldInterfaceUri, {
         applyResolution: false,
       });
-      if (!result2.ok) fail(result2.error);
-      expect(result2.value).toEqual([implementation1Uri]);
+      expect(result2).toEqual(ResultOk([implementation1Uri]));
 
       result2 = await client.getImplementations(oldInterfaceUri, {
         applyResolution: true,
       });
-      if (!result2.ok) fail(result2.error);
-      expect(result2.value).toEqual([implementation1Uri, implementation2Uri]);
+      expect(result2).toEqual(ResultOk([implementation1Uri, implementation2Uri]));
     });
   });
 };

--- a/packages/client/src/__tests__/core/wrap-features/subinvoke-case.ts
+++ b/packages/client/src/__tests__/core/wrap-features/subinvoke-case.ts
@@ -1,6 +1,7 @@
 import { GetPathToTestWrappers } from "@polywrap/test-cases";
 import { PolywrapClientConfigBuilder } from "@polywrap/client-config-builder-js";
 import { PolywrapClient } from "../../../PolywrapClient";
+import { ResultOk } from "@polywrap/result";
 
 export const subinvokeCase = (implementation: string) => {
   describe("wrapper subinvocation", () => {
@@ -23,9 +24,7 @@ export const subinvokeCase = (implementation: string) => {
         },
       });
 
-      if (!response.ok) fail(response.error);
-      expect(response.value).toBeTruthy();
-      expect(response.value).toEqual(3);
+      expect(response).toEqual(ResultOk(3));
     });
   });
 };

--- a/packages/config-builder/src/__tests__/client-config-builder.spec.ts
+++ b/packages/config-builder/src/__tests__/client-config-builder.spec.ts
@@ -174,8 +174,7 @@ describe("Client config builder", () => {
   });
 
   it("should successfully add the default config", async () => {
-    const builder = new PolywrapClientConfigBuilder()
-      .addDefaults();
+    const builder = new PolywrapClientConfigBuilder().addDefaults();
     const config = builder.config;
 
     expect(config).toBeTruthy();
@@ -184,12 +183,9 @@ describe("Client config builder", () => {
     // "sys", "web3"
     const expectedConfig = new PolywrapClientConfigBuilder()
       .addBundle("sys")
-      .addBundle("web3")
-      .config;
+      .addBundle("web3").config;
 
-    expect(JSON.stringify(config)).toBe(
-      JSON.stringify(expectedConfig)
-    );
+    expect(JSON.stringify(config)).toBe(JSON.stringify(expectedConfig));
   });
 
   it("should successfully add an env", () => {
@@ -201,13 +197,13 @@ describe("Client config builder", () => {
       },
     };
 
-    const config = new PolywrapClientConfigBuilder().addEnv(envUri, env).build();
+    const config = new PolywrapClientConfigBuilder()
+      .addEnv(envUri, env)
+      .build();
 
-    if (!config.envs || config.envs.size !== 1) {
-      fail(["Expected 1 env, received:", config.envs]);
-    }
-
-    expect(config.envs.get(Uri.from(envUri))).toEqual(env);
+    expect(config.envs).toBeTruthy();
+    expect(config.envs?.size).toBe(1);
+    expect(config.envs?.get(Uri.from(envUri))).toEqual(env);
   });
 
   it("should successfully add to an existing env", () => {
@@ -228,11 +224,9 @@ describe("Client config builder", () => {
 
     const expectedEnv = { ...env1, ...env2 };
 
-    if (!config.envs || config.envs.size !== 1) {
-      fail(["Expected 1 env, received:", config.envs]);
-    }
-
-    expect(config.envs.get(Uri.from(envUri))).toEqual(expectedEnv);
+    expect(config.envs).toBeTruthy();
+    expect(config.envs?.size).toBe(1);
+    expect(config.envs?.get(Uri.from(envUri))).toEqual(expectedEnv);
   });
 
   it("should succesfully add two separate envs", () => {
@@ -241,14 +235,13 @@ describe("Client config builder", () => {
       .addEnv(Object.keys(testEnvs)[1], Object.values(testEnvs)[1])
       .build();
 
-    if (!config.envs || config.envs.size !== 2) {
-      fail(["Expected 2 envs, received:", config.envs]);
-    }
+    expect(config.envs).toBeTruthy();
+    expect(config.envs?.size).toBe(2);
 
-    expect(config.envs.get(Uri.from(Object.keys(testEnvs)[0]))).toEqual(
+    expect(config.envs?.get(Uri.from(Object.keys(testEnvs)[0]))).toEqual(
       Object.values(testEnvs)[0]
     );
-    expect(config.envs.get(Uri.from(Object.keys(testEnvs)[0]))).toEqual(
+    expect(config.envs?.get(Uri.from(Object.keys(testEnvs)[0]))).toEqual(
       Object.values(testEnvs)[1]
     );
   });
@@ -260,11 +253,10 @@ describe("Client config builder", () => {
       .removeEnv(Object.keys(testEnvs)[0])
       .build();
 
-    if (!config.envs || config.envs.size !== 1) {
-      fail(["Expected 1 env, received:", config.envs]);
-    }
+    expect(config.envs).toBeTruthy();
+    expect(config.envs?.size).toBe(1);
 
-    expect(config.envs.get(Uri.from(Object.keys(testEnvs)[1]))).toEqual(
+    expect(config.envs?.get(Uri.from(Object.keys(testEnvs)[1]))).toEqual(
       Object.values(testEnvs)[1]
     );
   });
@@ -276,13 +268,14 @@ describe("Client config builder", () => {
       foo: "bar",
     };
 
-    const config = new PolywrapClientConfigBuilder().setEnv(envUri, env).build();
+    const config = new PolywrapClientConfigBuilder()
+      .setEnv(envUri, env)
+      .build();
 
-    if (!config.envs || config.envs.size !== 1) {
-      fail(["Expected 1 env, received:", config.envs]);
-    }
+    expect(config.envs).toBeTruthy();
+    expect(config.envs?.size).toBe(1);
 
-    expect(config.envs.get(Uri.from(envUri))).toEqual(env);
+    expect(config.envs?.get(Uri.from(envUri))).toEqual(env);
   });
 
   it("should set an env over an existing env", () => {
@@ -300,11 +293,10 @@ describe("Client config builder", () => {
       .setEnv(envUri, env2)
       .build();
 
-    if (!config.envs || config.envs.size !== 1) {
-      fail(["Expected 1 env, received:", config.envs]);
-    }
+    expect(config.envs).toBeTruthy();
+    expect(config.envs?.size).toBe(1);
 
-    expect(config.envs.get(Uri.from(envUri))).toEqual(env2);
+    expect(config.envs?.get(Uri.from(envUri))).toEqual(env2);
   });
 
   it("should add an interface implementation for a non-existent interface", () => {
@@ -315,9 +307,8 @@ describe("Client config builder", () => {
       .addInterfaceImplementation(interfaceUri, implUri)
       .build();
 
-    if (!config.interfaces || config.interfaces.size !== 1) {
-      fail(["Expected 1 interface, received:", config.interfaces]);
-    }
+    expect(config.interfaces).toBeTruthy();
+    expect(config.interfaces?.size).toBe(1);
 
     expect(config.interfaces).toStrictEqual(
       new UriMap([[Uri.from(interfaceUri), [Uri.from(implUri)]]])
@@ -334,9 +325,8 @@ describe("Client config builder", () => {
       .addInterfaceImplementation(interfaceUri, implUri2)
       .build();
 
-    if (!config.interfaces || config.interfaces.size !== 1) {
-      fail(["Expected 1 interface, received:", config.interfaces]);
-    }
+    expect(config.interfaces).toBeTruthy();
+    expect(config.interfaces?.size).toBe(1);
 
     expect(config.interfaces).toStrictEqual(
       new UriMap([
@@ -360,9 +350,8 @@ describe("Client config builder", () => {
       .addInterfaceImplementation(interfaceUri2, implUri4)
       .build();
 
-    if (!config.interfaces || config.interfaces.size !== 2) {
-      fail(["Expected 2 interfaces, received:", config.interfaces]);
-    }
+    expect(config.interfaces).toBeTruthy();
+    expect(config.interfaces?.size).toBe(2);
 
     expect(config.interfaces).toStrictEqual(
       new UriMap([
@@ -381,9 +370,8 @@ describe("Client config builder", () => {
       .addInterfaceImplementations(interfaceUri, [implUri1, implUri2])
       .build();
 
-    if (!config.interfaces || config.interfaces.size !== 1) {
-      fail(["Expected 1 interface, received:", config.interfaces]);
-    }
+    expect(config.interfaces).toBeTruthy();
+    expect(config.interfaces?.size).toBe(1);
 
     expect(config.interfaces).toStrictEqual(
       new UriMap([
@@ -403,9 +391,8 @@ describe("Client config builder", () => {
       .addInterfaceImplementations(interfaceUri, [implUri2, implUri3])
       .build();
 
-    if (!config.interfaces || config.interfaces.size !== 1) {
-      fail(["Expected 1 interface, received:", config.interfaces]);
-    }
+    expect(config.interfaces).toBeTruthy();
+    expect(config.interfaces?.size).toBe(1);
 
     expect(config.interfaces).toStrictEqual(
       new UriMap([
@@ -434,9 +421,8 @@ describe("Client config builder", () => {
       .addInterfaceImplementations(interfaceUri2, [implUri4, implUri6])
       .build();
 
-    if (!config.interfaces || config.interfaces.size !== 2) {
-      fail(["Expected 2 interfaces, received:", config.interfaces]);
-    }
+    expect(config.interfaces).toBeTruthy();
+    expect(config.interfaces?.size).toBe(2);
 
     expect(config.interfaces).toStrictEqual(
       new UriMap([
@@ -464,9 +450,8 @@ describe("Client config builder", () => {
       .removeInterfaceImplementation(interfaceUri1, implUri2)
       .build();
 
-    if (!config.interfaces || config.interfaces.size !== 2) {
-      fail(["Expected 2 interfaces, received:", config.interfaces]);
-    }
+    expect(config.interfaces).toBeTruthy();
+    expect(config.interfaces?.size).toBe(2);
 
     expect(config.interfaces).toStrictEqual(
       new UriMap([
@@ -489,9 +474,8 @@ describe("Client config builder", () => {
       .removeInterfaceImplementation(interfaceUri1, implUri2)
       .build();
 
-    if (!config.interfaces || config.interfaces.size !== 1) {
-      fail(["Expected 1 interface, received:", config.interfaces]);
-    }
+    expect(config.interfaces).toBeTruthy();
+    expect(config.interfaces?.size).toBe(1);
 
     expect(config.interfaces).toStrictEqual(
       new UriMap([
@@ -703,7 +687,8 @@ describe("Client config builder", () => {
       getManifest: jest.fn(),
     };
 
-    const builderConfig = new PolywrapClientConfigBuilder().setPackage(uri, pkg).config;
+    const builderConfig = new PolywrapClientConfigBuilder().setPackage(uri, pkg)
+      .config;
 
     expect(builderConfig.packages).toStrictEqual({
       [uri]: pkg,
@@ -784,8 +769,10 @@ describe("Client config builder", () => {
       invoke: jest.fn(),
     };
 
-    const builderConfig = new PolywrapClientConfigBuilder().setWrapper(uri, wrapper)
-      .config;
+    const builderConfig = new PolywrapClientConfigBuilder().setWrapper(
+      uri,
+      wrapper
+    ).config;
 
     expect(builderConfig.wrappers).toStrictEqual({
       [uri]: wrapper,

--- a/packages/core-client/src/__tests__/embedded-package.spec.ts
+++ b/packages/core-client/src/__tests__/embedded-package.spec.ts
@@ -36,11 +36,8 @@ describe("Embedded package", () => {
         b: 1
       },
     });
-
-    if (!result.ok) fail(result.error);
-    expect(result.value).toBeTruthy();
-    expect(typeof result.value).toBe("number");
-    expect(result.value).toEqual(2);
+    
+    expect(result).toStrictEqual(ResultOk(2));
   });
 
   it("can get a file from wrapper", async () => {
@@ -145,25 +142,18 @@ const testEmbeddedPackageWithFile = async (wrapPackage: IWrapPackage, filePath: 
   const receivedManifestResult = await client.getFile(wrapperUri, {
     path: "wrap.info",
   });
-  if (!receivedManifestResult.ok) fail(receivedManifestResult.error);
-  const receivedManifest = receivedManifestResult.value as Uint8Array;
-  expect(receivedManifest).toEqual(expectedManifest);
+  expect(receivedManifestResult).toEqual(ResultOk(expectedManifest));
 
   const expectedWasmModule = 
     await fs.promises.readFile(`${wrapperPath}/wrap.wasm`);
   const receivedWasmModuleResult = await client.getFile(wrapperUri, {
     path: "wrap.wasm",
   });
-  if (!receivedWasmModuleResult.ok) fail(receivedWasmModuleResult.error);
-  const receivedWasmModule = receivedWasmModuleResult.value as Uint8Array;
-  expect(receivedWasmModule).toEqual(expectedWasmModule);
+  expect(receivedWasmModuleResult).toEqual(ResultOk(expectedWasmModule));
 
   const receivedHelloFileResult = await client.getFile(wrapperUri, {
       path: filePath,
       encoding: "utf-8",
     });
-  if (!receivedHelloFileResult.ok) fail(receivedHelloFileResult.error);
-  const receivedHelloFile = receivedHelloFileResult.value as Uint8Array;
-
-  expect(receivedHelloFile).toEqual(fileText);
+  expect(receivedHelloFileResult).toEqual(ResultOk(fileText));
 };

--- a/packages/core-client/src/__tests__/embedded-wrapper.spec.ts
+++ b/packages/core-client/src/__tests__/embedded-wrapper.spec.ts
@@ -37,10 +37,7 @@ describe("Embedded wrapper", () => {
       },
     });
 
-    if (!result.ok) fail(result.error);
-    expect(result.value).toBeTruthy();
-    expect(typeof result.value).toBe("number");
-    expect(result.value).toEqual(2);
+    expect(result).toStrictEqual(ResultOk(2));
   });
 
   it("can get a file from wrapper", async () => {
@@ -145,25 +142,18 @@ const testEmbeddedWrapperWithFile = async (wrapper: WasmWrapper, filePath: strin
   const receivedManifestResult = await client.getFile(wrapperUri, {
     path: "wrap.info",
   });
-  if (!receivedManifestResult.ok) fail(receivedManifestResult.error);
-  const receivedManifest = receivedManifestResult.value as Uint8Array;
-  expect(receivedManifest).toEqual(expectedManifest);
+  expect(receivedManifestResult).toEqual(ResultOk(expectedManifest));
 
   const expectedWasmModule = 
     await fs.promises.readFile(`${wrapperPath}/wrap.wasm`);
   const receivedWasmModuleResult = await client.getFile(wrapperUri, {
     path: "wrap.wasm",
   });
-  if (!receivedWasmModuleResult.ok) fail(receivedWasmModuleResult.error);
-  const receivedWasmModule = receivedWasmModuleResult.value as Uint8Array;
-  expect(receivedWasmModule).toEqual(expectedWasmModule);
+  expect(receivedWasmModuleResult).toEqual(ResultOk(expectedWasmModule));
 
   const receivedHelloFileResult = await client.getFile(wrapperUri, {
       path: filePath,
       encoding: "utf-8",
     });
-  if (!receivedHelloFileResult.ok) fail(receivedHelloFileResult.error);
-  const receivedHelloFile = receivedHelloFileResult.value as Uint8Array;
-
-  expect(receivedHelloFile).toEqual(fileText);
+  expect(receivedHelloFileResult).toEqual(ResultOk(fileText));
 };

--- a/packages/uri-resolver-extensions/src/__tests__/helpers/expectHistory.ts
+++ b/packages/uri-resolver-extensions/src/__tests__/helpers/expectHistory.ts
@@ -7,16 +7,19 @@ export const expectHistory = async (
   historyFileName: string,
   replaceFilePaths?: boolean
 ): Promise<void> => {
-  if (!receivedHistory) {
-    fail("History is not defined");
-  }
+  expect(receivedHistory).toBeTruthy();
+
+  if (!receivedHistory) return;
 
   const expectedCleanHistoryStr = await fs.promises.readFile(
     `${__dirname}/../histories/${historyFileName}.json`,
     "utf-8"
   );
-  const expectedCleanHistory = JSON.stringify(JSON.parse(expectedCleanHistoryStr), null, 2);
-
+  const expectedCleanHistory = JSON.stringify(
+    JSON.parse(expectedCleanHistoryStr),
+    null,
+    2
+  );
 
   let receivedCleanHistory = replaceAll(
     JSON.stringify(buildCleanUriHistory(receivedHistory), null, 2),

--- a/packages/uri-resolvers/src/__tests__/aggregator-resolver/aggregator-resolver.spec.ts
+++ b/packages/uri-resolvers/src/__tests__/aggregator-resolver/aggregator-resolver.spec.ts
@@ -1,29 +1,30 @@
-import {
-  Uri,
-  UriResolutionContext,
-} from "@polywrap/core-js";
+import { Uri, UriResolutionContext } from "@polywrap/core-js";
 import { expectHistory } from "../helpers/expectHistory";
 import { PolywrapCoreClient } from "@polywrap/core-client-js";
 import { UriResolverAggregator } from "../../aggregator";
+import { ResultOk } from "@polywrap/result";
 
 jest.setTimeout(20000);
 
 describe("UriResolverAggregator", () => {
   const client = new PolywrapCoreClient({
-    resolver: new UriResolverAggregator([
-      {
-        from: Uri.from("test/1"),
-        to: Uri.from("test/2")
-      },
-      {
-        from: Uri.from("test/2"),
-        to: Uri.from("test/3")
-      },
-      {
-        from: Uri.from("test/3"),
-        to: Uri.from("test/4")
-      }
-    ], "TestAggregator")
+    resolver: new UriResolverAggregator(
+      [
+        {
+          from: Uri.from("test/1"),
+          to: Uri.from("test/2"),
+        },
+        {
+          from: Uri.from("test/2"),
+          to: Uri.from("test/3"),
+        },
+        {
+          from: Uri.from("test/3"),
+          to: Uri.from("test/4"),
+        },
+      ],
+      "TestAggregator"
+    ),
   });
 
   it("can resolve using first resolver", async () => {
@@ -35,18 +36,17 @@ describe("UriResolverAggregator", () => {
     await expectHistory(
       resolutionContext.getHistory(),
       "aggregator-resolver",
-      "can-resolve-using-first-resolver",
+      "can-resolve-using-first-resolver"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "uri") {
-      fail("Expected a uri, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/2");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: "wrap://test/2",
+        },
+      })
+    );
   });
 
   it("can resolve using last resolver", async () => {
@@ -58,20 +58,18 @@ describe("UriResolverAggregator", () => {
     await expectHistory(
       resolutionContext.getHistory(),
       "aggregator-resolver",
-      "can-resolve-using-last-resolver",
+      "can-resolve-using-last-resolver"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "uri") {
-      fail("Expected a uri, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/4");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: "wrap://test/4",
+        },
+      })
+    );
   });
-
 
   it("does not resolve a uri when not a match", async () => {
     const uri = new Uri("test/not-a-match");
@@ -82,17 +80,16 @@ describe("UriResolverAggregator", () => {
     await expectHistory(
       resolutionContext.getHistory(),
       "aggregator-resolver",
-      "not-a-match",
+      "not-a-match"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "uri") {
-      fail("Expected a uri, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/not-a-match");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: "wrap://test/not-a-match",
+        },
+      })
+    );
   });
 });

--- a/packages/uri-resolvers/src/__tests__/helpers/expectHistory.ts
+++ b/packages/uri-resolvers/src/__tests__/helpers/expectHistory.ts
@@ -6,17 +6,25 @@ export const expectHistory = async (
   directory: string,
   historyFileName: string
 ): Promise<void> => {
-  if (!receivedHistory) {
-    fail("History is not defined");
-  }
+  expect(receivedHistory).toBeTruthy();
+
+  if (!receivedHistory) return;
 
   const expectedCleanHistoryStr = await fs.promises.readFile(
     `${__dirname}/../${directory}/histories/${historyFileName}.json`,
     "utf-8"
   );
-  const expectedCleanHistory = JSON.stringify(JSON.parse(expectedCleanHistoryStr), null, 2);
+  const expectedCleanHistory = JSON.stringify(
+    JSON.parse(expectedCleanHistoryStr),
+    null,
+    2
+  );
 
-  const receivedCleanHistory = JSON.stringify(buildCleanUriHistory(receivedHistory), null, 2);
+  const receivedCleanHistory = JSON.stringify(
+    buildCleanUriHistory(receivedHistory),
+    null,
+    2
+  );
 
   expect(receivedCleanHistory).toEqual(expectedCleanHistory);
 };

--- a/packages/uri-resolvers/src/__tests__/package-resolver/package-resolver.spec.ts
+++ b/packages/uri-resolvers/src/__tests__/package-resolver/package-resolver.spec.ts
@@ -1,11 +1,9 @@
-import {
-  Uri,
-  UriResolutionContext,
-} from "@polywrap/core-js";
+import { Uri, UriResolutionContext } from "@polywrap/core-js";
 import { expectHistory } from "../helpers/expectHistory";
 import { PolywrapCoreClient } from "@polywrap/core-client-js";
 import { PackageResolver } from "../../packages";
 import { PluginPackage } from "@polywrap/plugin-js";
+import { ResultOk } from "@polywrap/result";
 
 jest.setTimeout(20000);
 
@@ -17,7 +15,7 @@ describe("PackageResolver", () => {
       resolver: new PackageResolver(
         Uri.from("test/package"),
         PluginPackage.from(() => ({}))
-      )
+      ),
     });
 
     let resolutionContext = new UriResolutionContext();
@@ -26,18 +24,17 @@ describe("PackageResolver", () => {
     await expectHistory(
       resolutionContext.getHistory(),
       "package-resolver",
-      "can-resolve-a-package",
+      "can-resolve-a-package"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "package") {
-      fail("Expected a package, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/package");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "package",
+        uri: {
+          uri: "wrap://test/package",
+        },
+      })
+    );
   });
 
   it("does not resolve a package when not a match", async () => {
@@ -47,7 +44,7 @@ describe("PackageResolver", () => {
       resolver: new PackageResolver(
         Uri.from("test/package"),
         PluginPackage.from(() => ({}))
-      )
+      ),
     });
 
     let resolutionContext = new UriResolutionContext();
@@ -56,17 +53,16 @@ describe("PackageResolver", () => {
     await expectHistory(
       resolutionContext.getHistory(),
       "package-resolver",
-      "not-a-match",
+      "not-a-match"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "uri") {
-      fail("Expected a uri, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/not-a-match");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: "wrap://test/not-a-match",
+        },
+      })
+    );
   });
 });

--- a/packages/uri-resolvers/src/__tests__/package-to-wrapper-resolver/package-to-wrapper.spec.ts
+++ b/packages/uri-resolvers/src/__tests__/package-to-wrapper-resolver/package-to-wrapper.spec.ts
@@ -12,6 +12,7 @@ import { expectHistory } from "../helpers/expectHistory";
 import { PolywrapCoreClient } from "@polywrap/core-client-js";
 import { PluginPackage } from "@polywrap/plugin-js";
 import { PackageToWrapperResolver } from "../../packages";
+import { ResultOk } from "@polywrap/result";
 
 jest.setTimeout(20000);
 
@@ -77,15 +78,14 @@ describe("PackageToWrapperResolver", () => {
       "package-to-wrapper"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "wrapper") {
-      fail("Expected a wrapper, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/package");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "wrapper",
+        uri: {
+          uri: "wrap://test/package",
+        },
+      })
+    );
   });
 
   it("resolves a wrapper to a wrapper", async () => {
@@ -104,15 +104,14 @@ describe("PackageToWrapperResolver", () => {
       "wrapper-to-wrapper"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "wrapper") {
-      fail("Expected a wrapper, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/wrapper");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "wrapper",
+        uri: {
+          uri: "wrap://test/wrapper",
+        },
+      })
+    );
   });
 
   it("resolves a URI to a URI", async () => {
@@ -131,14 +130,13 @@ describe("PackageToWrapperResolver", () => {
       "uri-to-uri"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "uri") {
-      fail("Expected a URI, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/to");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: "wrap://test/to",
+        },
+      })
+    );
   });
 });

--- a/packages/uri-resolvers/src/__tests__/recursive-resolver/recursive-resolver.spec.ts
+++ b/packages/uri-resolvers/src/__tests__/recursive-resolver/recursive-resolver.spec.ts
@@ -11,6 +11,7 @@ import {
 import { expectHistory } from "../helpers/expectHistory";
 import { PolywrapCoreClient } from "@polywrap/core-client-js";
 import { RecursiveResolver } from "../../helpers";
+import { ResultErr, ResultOk } from "@polywrap/result";
 
 jest.setTimeout(20000);
 
@@ -95,15 +96,14 @@ describe("RecursiveResolver", () => {
       "can-recursively-resolve-uri"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "uri") {
-      fail("Expected a URI, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/4");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: "wrap://test/4",
+        },
+      })
+    );
   });
 
   it("does not resolve a uri when not a match", async () => {
@@ -122,15 +122,14 @@ describe("RecursiveResolver", () => {
       "not-a-match"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "uri") {
-      fail("Expected a uri, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/not-a-match");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: "wrap://test/not-a-match",
+        },
+      })
+    );
   });
 
   it("should raise an error if infinite loop detected during URI Resolution", async () => {
@@ -149,11 +148,11 @@ describe("RecursiveResolver", () => {
       "infinite-loop"
     );
 
-    if (result.ok) {
-      fail(`Expected an error got value: ${result.value}`);
-    }
+    expect(result).toMatchObject(ResultErr({}));
 
     // @ts-ignore
-    expect(result.error!.message).toMatch("An infinite loop was detected while resolving the URI: wrap://test/1");
-  })
+    expect(result.error!.message).toMatch(
+      "An infinite loop was detected while resolving the URI: wrap://test/1"
+    );
+  });
 });

--- a/packages/uri-resolvers/src/__tests__/redirect-resolver/redirect-resolver.spec.ts
+++ b/packages/uri-resolvers/src/__tests__/redirect-resolver/redirect-resolver.spec.ts
@@ -1,10 +1,8 @@
-import {
-  Uri,
-  UriResolutionContext,
-} from "@polywrap/core-js";
+import { Uri, UriResolutionContext } from "@polywrap/core-js";
 import { expectHistory } from "../helpers/expectHistory";
 import { PolywrapCoreClient } from "@polywrap/core-client-js";
 import { RedirectResolver } from "../../redirects";
+import { ResultOk } from "@polywrap/result";
 
 jest.setTimeout(20000);
 
@@ -15,8 +13,8 @@ describe("RedirectResolver", () => {
     const client = new PolywrapCoreClient({
       resolver: new RedirectResolver(
         Uri.from("test/from"),
-        Uri.from("test/to"),
-      )
+        Uri.from("test/to")
+      ),
     });
 
     let resolutionContext = new UriResolutionContext();
@@ -25,18 +23,17 @@ describe("RedirectResolver", () => {
     await expectHistory(
       resolutionContext.getHistory(),
       "redirect-resolver",
-      "can-redirect-a-uri",
+      "can-redirect-a-uri"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "uri") {
-      fail("Expected a uri, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/to");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: "wrap://test/to",
+        },
+      })
+    );
   });
 
   it("does not redirect a URI when not a match", async () => {
@@ -45,8 +42,8 @@ describe("RedirectResolver", () => {
     const client = new PolywrapCoreClient({
       resolver: new RedirectResolver(
         Uri.from("test/from"),
-        Uri.from("test/to"),
-      )
+        Uri.from("test/to")
+      ),
     });
 
     let resolutionContext = new UriResolutionContext();
@@ -55,17 +52,16 @@ describe("RedirectResolver", () => {
     await expectHistory(
       resolutionContext.getHistory(),
       "redirect-resolver",
-      "not-a-match",
+      "not-a-match"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "uri") {
-      fail("Expected a uri, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/not-a-match");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: "wrap://test/not-a-match",
+        },
+      })
+    );
   });
 });

--- a/packages/uri-resolvers/src/__tests__/redirects.spec.ts
+++ b/packages/uri-resolvers/src/__tests__/redirects.spec.ts
@@ -1,8 +1,5 @@
-import {
-  Uri,
-  CoreClient,
-  UriResolutionContext,
-} from "@polywrap/core-js";
+import { Uri, CoreClient, UriResolutionContext } from "@polywrap/core-js";
+import { ResultErr, ResultOk } from "@polywrap/result";
 import { InfiniteLoopError, RecursiveResolver, UriResolver } from "../helpers";
 import { StaticResolver } from "../static";
 
@@ -10,43 +7,43 @@ describe("redirects", () => {
   it("sanity - UriResolver", async () => {
     const uri1 = Uri.from("wrap://ens/some-uri1.eth");
     const uri2 = Uri.from("wrap://ens/some-uri2.eth");
-    const resolver = UriResolver.from([
-      { from: uri1, to: uri2 }
-    ]);
+    const resolver = UriResolver.from([{ from: uri1, to: uri2 }]);
 
-    const redirectsResult = await resolver.tryResolveUri(uri1, {} as CoreClient, new UriResolutionContext());
+    const redirectsResult = await resolver.tryResolveUri(
+      uri1,
+      {} as CoreClient,
+      new UriResolutionContext()
+    );
 
-    if (!redirectsResult.ok) {
-      fail(redirectsResult.error);
-    }
-
-    if (redirectsResult.value.type !== "uri") {
-      console.error(`Expected URI, received: `, redirectsResult.value);
-      fail();
-    }
-
-    expect(redirectsResult.value.uri.uri).toEqual(uri2.uri);
+    expect(redirectsResult).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: uri2.uri,
+        },
+      })
+    );
   });
 
   it("sanity - StaticResolver", async () => {
     const uri1 = Uri.from("wrap://ens/some-uri1.eth");
     const uri2 = Uri.from("wrap://ens/some-uri2.eth");
-    const resolver = StaticResolver.from([
-      { from: uri1, to: uri2 }
-    ]);
+    const resolver = StaticResolver.from([{ from: uri1, to: uri2 }]);
 
-    const redirectsResult = await resolver.tryResolveUri(uri1, {} as CoreClient, new UriResolutionContext());
+    const redirectsResult = await resolver.tryResolveUri(
+      uri1,
+      {} as CoreClient,
+      new UriResolutionContext()
+    );
 
-    if (!redirectsResult.ok) {
-      fail(redirectsResult.error);
-    }
-
-    if (redirectsResult.value.type !== "uri") {
-      console.log(`Expected URI, received: `, redirectsResult.value);
-      fail();
-    }
-
-    expect(redirectsResult.value.uri.uri).toEqual(uri2.uri);
+    expect(redirectsResult).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: uri2.uri,
+        },
+      })
+    );
   });
 
   it("works with the redirect stack overrides - RecursiveResolver", async () => {
@@ -57,26 +54,28 @@ describe("redirects", () => {
     const resolver = RecursiveResolver.from([
       {
         from: uri1,
-        to: uri2
+        to: uri2,
       },
       {
         from: uri2,
-        to: uri3
-      }
+        to: uri3,
+      },
     ]);
 
-    const redirectsResult = await resolver.tryResolveUri(uri1, {} as CoreClient, new UriResolutionContext());
+    const redirectsResult = await resolver.tryResolveUri(
+      uri1,
+      {} as CoreClient,
+      new UriResolutionContext()
+    );
 
-    if (!redirectsResult.ok) {
-      fail(redirectsResult.error);
-    }
-
-    if (redirectsResult.value.type !== "uri") {
-      console.error(`Expected URI, received: `, redirectsResult.value);
-      fail();
-    }
-
-    expect(redirectsResult.value.uri.uri).toEqual(uri3.uri);
+    expect(redirectsResult).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: uri3.uri,
+        },
+      })
+    );
   });
 
   it("works with the redirect stack overrides - RecursiveResolver with StaticResolver", async () => {
@@ -88,27 +87,29 @@ describe("redirects", () => {
       StaticResolver.from([
         {
           from: uri1,
-          to: uri2
+          to: uri2,
         },
         {
           from: uri2,
-          to: uri3
-        }
+          to: uri3,
+        },
       ])
     );
 
-    const redirectsResult = await resolver.tryResolveUri(uri1, {} as CoreClient, new UriResolutionContext());
+    const redirectsResult = await resolver.tryResolveUri(
+      uri1,
+      {} as CoreClient,
+      new UriResolutionContext()
+    );
 
-    if (!redirectsResult.ok) {
-      fail(redirectsResult.error);
-    }
-
-    if (redirectsResult.value.type !== "uri") {
-      console.log(`Expected URI, received: `, redirectsResult.value);
-      fail();
-    }
-
-    expect(redirectsResult.value.uri.uri).toEqual(uri3.uri);
+    expect(redirectsResult).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: uri3.uri,
+        },
+      })
+    );
   });
 
   it("can not redirect to self - RecursiveResolver", async () => {
@@ -118,24 +119,27 @@ describe("redirects", () => {
     const resolver = RecursiveResolver.from([
       {
         from: uri1,
-        to: uri2
+        to: uri2,
       },
       {
         from: uri2,
-        to: uri1
+        to: uri1,
       },
     ]);
 
-    const redirectsResult = await resolver.tryResolveUri(uri1, {} as CoreClient, new UriResolutionContext());
+    const redirectsResult = await resolver.tryResolveUri(
+      uri1,
+      {} as CoreClient,
+      new UriResolutionContext()
+    );
 
-    if (redirectsResult.ok) {
-      console.error(`Expected error`, redirectsResult.value);
-      fail();
-    }
+    expect(redirectsResult).toMatchObject(ResultErr({}));
 
-    expect((redirectsResult.error as InfiniteLoopError).message).toContain("An infinite loop was detected while resolving the URI");
+    !redirectsResult.ok &&
+      expect((redirectsResult.error as InfiniteLoopError).message).toContain(
+        "An infinite loop was detected while resolving the URI"
+      );
   });
-
 
   it("can not redirect to self - RecursiveResolver with StaticResolver", async () => {
     const uri1 = Uri.from("wrap://ens/some-uri1.eth");
@@ -145,22 +149,26 @@ describe("redirects", () => {
       StaticResolver.from([
         {
           from: uri1,
-          to: uri2
+          to: uri2,
         },
         {
           from: uri2,
-          to: uri1
+          to: uri1,
         },
-      ]
-    ));
+      ])
+    );
 
-    const redirectsResult = await resolver.tryResolveUri(uri1, {} as CoreClient, new UriResolutionContext());
+    const redirectsResult = await resolver.tryResolveUri(
+      uri1,
+      {} as CoreClient,
+      new UriResolutionContext()
+    );
 
-    if (redirectsResult.ok) {
-      console.log(`Expected error`, redirectsResult.value);
-      fail();
-    }
+    expect(redirectsResult).toMatchObject(ResultErr({}));
 
-    expect((redirectsResult.error as InfiniteLoopError).message).toContain("An infinite loop was detected while resolving the URI");
+    !redirectsResult.ok &&
+      expect((redirectsResult.error as InfiniteLoopError).message).toContain(
+        "An infinite loop was detected while resolving the URI"
+      );
   });
 });

--- a/packages/uri-resolvers/src/__tests__/resolution-result-cache-resolver/resolution-result-cache-resolver.spec.ts
+++ b/packages/uri-resolvers/src/__tests__/resolution-result-cache-resolver/resolution-result-cache-resolver.spec.ts
@@ -14,6 +14,7 @@ import { PolywrapCoreClient } from "@polywrap/core-client-js";
 import { PluginPackage } from "@polywrap/plugin-js";
 import { ResolutionResultCacheResolver } from "../../cache/ResolutionResultCacheResolver";
 import { ResolutionResultCache } from "../../cache/ResolutionResultCache";
+import { ResultErr, ResultOk } from "@polywrap/result";
 
 jest.setTimeout(20000);
 
@@ -91,15 +92,14 @@ describe("ResolutionResultCacheResolver", () => {
       "wrapper-without-cache"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "wrapper") {
-      fail("Expected a wrapper, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/wrapper");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "wrapper",
+        uri: {
+          uri: "wrap://test/wrapper",
+        },
+      })
+    );
 
     resolutionContext = new UriResolutionContext();
     result = await client.tryResolveUri({ uri, resolutionContext });
@@ -110,15 +110,14 @@ describe("ResolutionResultCacheResolver", () => {
       "wrapper-with-cache"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "wrapper") {
-      fail("Expected a wrapper, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/wrapper");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "wrapper",
+        uri: {
+          uri: "wrap://test/wrapper",
+        },
+      })
+    );
   });
 
   it("caches a resolved URI", async () => {
@@ -140,15 +139,14 @@ describe("ResolutionResultCacheResolver", () => {
       "uri-without-cache"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "uri") {
-      fail("Expected a uri, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/to");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: "wrap://test/to",
+        },
+      })
+    );
 
     resolutionContext = new UriResolutionContext();
     result = await client.tryResolveUri({ uri, resolutionContext });
@@ -159,15 +157,14 @@ describe("ResolutionResultCacheResolver", () => {
       "uri-with-cache"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "uri") {
-      fail("Expected a uri, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/to");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: "wrap://test/to",
+        },
+      })
+    );
   });
 
   it("caches a resolved package", async () => {
@@ -189,15 +186,14 @@ describe("ResolutionResultCacheResolver", () => {
       "package-without-cache"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "package") {
-      fail("Expected a package, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/package");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "package",
+        uri: {
+          uri: "wrap://test/package",
+        },
+      })
+    );
 
     resolutionContext = new UriResolutionContext();
     result = await client.tryResolveUri({ uri, resolutionContext });
@@ -208,15 +204,14 @@ describe("ResolutionResultCacheResolver", () => {
       "package-with-cache"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "package") {
-      fail("Expected a package, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/package");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "package",
+        uri: {
+          uri: "wrap://test/package",
+        },
+      })
+    );
   });
 
   it("does not cache error by default", async () => {
@@ -239,10 +234,10 @@ describe("ResolutionResultCacheResolver", () => {
       "error-without-cache"
     );
 
-    if (result.ok) {
-      fail("Expected an error, received: " + result.value.type);
-    }
-    expect((result.error as Error)?.message).toEqual("A test error");
+    expect(result).toMatchObject(ResultErr({}));
+
+    !result.ok &&
+      expect((result.error as Error)?.message).toEqual("A test error");
 
     resolutionContext = new UriResolutionContext();
     result = await client.tryResolveUri({
@@ -256,10 +251,10 @@ describe("ResolutionResultCacheResolver", () => {
       "error-without-cache"
     );
 
-    if (result.ok) {
-      fail("Expected an error, received: " + result.value.type);
-    }
-    expect((result.error as Error)?.message).toEqual("A test error");
+    expect(result).toMatchObject(ResultErr({}));
+
+    !result.ok &&
+      expect((result.error as Error)?.message).toEqual("A test error");
   });
 
   it("caches error if configured", async () => {
@@ -285,10 +280,10 @@ describe("ResolutionResultCacheResolver", () => {
       "error-without-cache"
     );
 
-    if (result.ok) {
-      fail("Expected an error, received: " + result.value.type);
-    }
-    expect((result.error as Error)?.message).toEqual("A test error");
+    expect(result).toMatchObject(ResultErr({}));
+
+    !result.ok &&
+      expect((result.error as Error)?.message).toEqual("A test error");
 
     resolutionContext = new UriResolutionContext();
     result = await client.tryResolveUri({
@@ -302,10 +297,10 @@ describe("ResolutionResultCacheResolver", () => {
       "error-with-cache"
     );
 
-    if (result.ok) {
-      fail("Expected an error, received: " + result.value.type);
-    }
-    expect((result.error as Error)?.message).toEqual("A test error");
+    expect(result).toMatchObject(ResultErr({}));
+
+    !result.ok &&
+      expect((result.error as Error)?.message).toEqual("A test error");
   });
 
   it("keeps the same resolution path after caching", async () => {

--- a/packages/uri-resolvers/src/__tests__/static-resolver/static-resolver.spec.ts
+++ b/packages/uri-resolvers/src/__tests__/static-resolver/static-resolver.spec.ts
@@ -7,6 +7,7 @@ import {
 import { expectHistory } from "../helpers/expectHistory";
 import { PolywrapCoreClient } from "@polywrap/core-client-js";
 import { StaticResolver } from "../../static";
+import { ResultOk } from "@polywrap/result";
 
 jest.setTimeout(20000);
 
@@ -32,15 +33,14 @@ describe("StaticResolver", () => {
       "can-redirect-a-uri"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "uri") {
-      fail("Expected a uri, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/to");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: "wrap://test/to",
+        },
+      })
+    );
   });
 
   it("can resolve a package", async () => {
@@ -64,15 +64,14 @@ describe("StaticResolver", () => {
       "can-resolve-a-package"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "package") {
-      fail("Expected a package, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/package");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "package",
+        uri: {
+          uri: "wrap://test/package",
+        },
+      })
+    );
   });
 
   it("can resolve a wrapper", async () => {
@@ -96,15 +95,14 @@ describe("StaticResolver", () => {
       "can-resolve-a-wrapper"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "wrapper") {
-      fail("Expected a wrapper, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/wrapper");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "wrapper",
+        uri: {
+          uri: "wrap://test/wrapper",
+        },
+      })
+    );
   });
 
   it("can not resolve unregistered uri", async () => {
@@ -123,14 +121,13 @@ describe("StaticResolver", () => {
       "not-a-match"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "uri") {
-      fail("Expected a uri, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/not-a-match");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: "wrap://test/not-a-match",
+        },
+      })
+    );
   });
 });

--- a/packages/uri-resolvers/src/__tests__/wrapper-cache-resolver/wrapper-cache-resolver.spec.ts
+++ b/packages/uri-resolvers/src/__tests__/wrapper-cache-resolver/wrapper-cache-resolver.spec.ts
@@ -13,6 +13,7 @@ import { RecursiveResolver } from "../../helpers";
 import { PolywrapCoreClient } from "@polywrap/core-client-js";
 import { PluginPackage } from "@polywrap/plugin-js";
 import { WrapperCache, WrapperCacheResolver } from "../../cache";
+import { ResultOk } from "@polywrap/result";
 
 jest.setTimeout(20000);
 
@@ -85,15 +86,14 @@ describe("WrapperCacheResolver", () => {
       "wrapper-without-cache"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "wrapper") {
-      fail("Expected a wrapper, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/wrapper");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "wrapper",
+        uri: {
+          uri: "wrap://test/wrapper",
+        },
+      })
+    );
 
     resolutionContext = new UriResolutionContext();
     result = await client.tryResolveUri({ uri, resolutionContext });
@@ -104,15 +104,14 @@ describe("WrapperCacheResolver", () => {
       "wrapper-with-cache"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "wrapper") {
-      fail("Expected a wrapper, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/wrapper");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "wrapper",
+        uri: {
+          uri: "wrap://test/wrapper",
+        },
+      })
+    );
   });
 
   it("does not cache a URI", async () => {
@@ -134,15 +133,14 @@ describe("WrapperCacheResolver", () => {
       "uri-without-cache"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "uri") {
-      fail("Expected a uri, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/to");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: "wrap://test/to",
+        },
+      })
+    );
 
     resolutionContext = new UriResolutionContext();
     result = await client.tryResolveUri({ uri, resolutionContext });
@@ -153,15 +151,14 @@ describe("WrapperCacheResolver", () => {
       "uri-without-cache"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "uri") {
-      fail("Expected a uri, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/to");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: "wrap://test/to",
+        },
+      })
+    );
   });
 
   it("does not cache a package", async () => {
@@ -183,15 +180,14 @@ describe("WrapperCacheResolver", () => {
       "package-without-cache"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "package") {
-      fail("Expected a package, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/package");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "package",
+        uri: {
+          uri: "wrap://test/package",
+        },
+      })
+    );
 
     resolutionContext = new UriResolutionContext();
     result = await client.tryResolveUri({ uri, resolutionContext });
@@ -202,15 +198,14 @@ describe("WrapperCacheResolver", () => {
       "package-without-cache"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "package") {
-      fail("Expected a package, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/package");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "package",
+        uri: {
+          uri: "wrap://test/package",
+        },
+      })
+    );
   });
 
   it("caches the whole resolution path", async () => {
@@ -233,15 +228,14 @@ describe("WrapperCacheResolver", () => {
       "resolution-path-without-cache"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "wrapper") {
-      fail("Expected a wrapper, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/wrapper");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "wrapper",
+        uri: {
+          uri: "wrap://test/wrapper",
+        },
+      })
+    );
 
     resolutionContext = new UriResolutionContext();
     result = await client.tryResolveUri({
@@ -255,15 +249,14 @@ describe("WrapperCacheResolver", () => {
       "resolution-path-A-with-cache"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "wrapper") {
-      fail("Expected a wrapper, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/A");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "wrapper",
+        uri: {
+          uri: "wrap://test/A",
+        },
+      })
+    );
 
     resolutionContext = new UriResolutionContext();
     result = await client.tryResolveUri({
@@ -277,15 +270,14 @@ describe("WrapperCacheResolver", () => {
       "resolution-path-B-with-cache"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "wrapper") {
-      fail("Expected a wrapper, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/B");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "wrapper",
+        uri: {
+          uri: "wrap://test/B",
+        },
+      })
+    );
 
     resolutionContext = new UriResolutionContext();
     result = await client.tryResolveUri({
@@ -299,14 +291,13 @@ describe("WrapperCacheResolver", () => {
       "resolution-path-wrapper-with-cache"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "wrapper") {
-      fail("Expected a wrapper, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/wrapper");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "wrapper",
+        uri: {
+          uri: "wrap://test/wrapper",
+        },
+      })
+    );
   });
 });

--- a/packages/uri-resolvers/src/__tests__/wrapper-resolver/wrapper-resolver.spec.ts
+++ b/packages/uri-resolvers/src/__tests__/wrapper-resolver/wrapper-resolver.spec.ts
@@ -1,11 +1,9 @@
-import {
-  Uri,
-  UriResolutionContext,
-} from "@polywrap/core-js";
+import { Uri, UriResolutionContext } from "@polywrap/core-js";
 import { expectHistory } from "../helpers/expectHistory";
 import { PolywrapCoreClient } from "@polywrap/core-client-js";
 import { PluginPackage } from "@polywrap/plugin-js";
 import { WrapperResolver } from "../../wrappers";
+import { ResultOk } from "@polywrap/result";
 
 jest.setTimeout(20000);
 
@@ -22,7 +20,7 @@ describe("WrapperResolver", () => {
       resolver: new WrapperResolver(
         Uri.from("test/wrapper"),
         wrapperResult.value
-      )
+      ),
     });
 
     let resolutionContext = new UriResolutionContext();
@@ -31,18 +29,17 @@ describe("WrapperResolver", () => {
     await expectHistory(
       resolutionContext.getHistory(),
       "wrapper-resolver",
-      "can-resolve-a-wrapper",
+      "can-resolve-a-wrapper"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "wrapper") {
-      fail("Expected a wrapper, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/wrapper");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "wrapper",
+        uri: {
+          uri: "wrap://test/wrapper",
+        },
+      })
+    );
   });
 
   it("does not resolve a wrapper when not a match", async () => {
@@ -57,7 +54,7 @@ describe("WrapperResolver", () => {
       resolver: new WrapperResolver(
         Uri.from("test/wrapper"),
         wrapperResult.value
-      )
+      ),
     });
 
     let resolutionContext = new UriResolutionContext();
@@ -66,17 +63,16 @@ describe("WrapperResolver", () => {
     await expectHistory(
       resolutionContext.getHistory(),
       "wrapper-resolver",
-      "not-a-match",
+      "not-a-match"
     );
 
-    if (!result.ok) {
-      fail(result.error);
-    }
-
-    if (result.value.type !== "uri") {
-      fail("Expected a uri, received: " + result.value.type);
-    }
-
-    expect(result.value.uri.uri).toEqual("wrap://test/not-a-match");
+    expect(result).toMatchObject(
+      ResultOk({
+        type: "uri",
+        uri: {
+          uri: "wrap://test/not-a-match",
+        },
+      })
+    );
   });
 });


### PR DESCRIPTION
With Jest's newish `circus` runner, [the global `fail()` function no longer exists](https://github.com/jestjs/jest/issues/11698), although it is present in `@types/jest`, due to its presence in the `jest-jasmine2` runner which has been replaced by `circus` as the default runner.

In this PR, I have opted to clean up our tests by removing calls to `fail()` and replacing them with proper assertions.

This also simplifies our testing infrastructure, making it more resilient to changes in our `Result` type by leveraging comparison assertions using `ResultOK` and `ResultErr`.