### PR TITLE
URI authority should start with word characters

### DIFF
--- a/packages/core/src/__tests__/Uri.spec.ts
+++ b/packages/core/src/__tests__/Uri.spec.ts
@@ -78,4 +78,10 @@ describe("Uri", () => {
     expect(uri.authority).toEqual("authority");
     expect(uri.path).toEqual("something?uri=wrap://something/something2");
   });
+
+  it("Shouldn't accept authorities that don't start with alphanumeric characters", () => {
+    expect(() => {
+      new Uri("../invalid/path");
+    }).toThrow(/URI authority must start with an alphanumeric character or an underscore\./);
+  });
 });

--- a/packages/core/src/types/Uri.ts
+++ b/packages/core/src/types/Uri.ts
@@ -175,6 +175,18 @@ export class Uri {
 
     // Extract the authority and path
     const authority = parts[0];
+
+    // Authority should begin with a word character (alphanumeric, underscore)
+    const validAuthorityRegExp = /^\w.*/;
+    if (!validAuthorityRegExp.test(authority)) {
+      return ResultErr(
+        Error(
+          `URI authority must start with an alphanumeric character or an underscore.\n` +
+            `Invalid URI Received: ${input}`
+        )
+      );
+    }
+
     const path = parts.slice(1).join("/");
 
     if (!path) {


### PR DESCRIPTION
Following an investigation into failing tests in our `schema-compose` package as part of work on https://github.com/polywrap/cli/pull/1827 , I have found out that our `Uri` implementation accepts strings like `./some/path` and `../some/path` as valid URIs, with their `authority` being `.` and `..` respectively.

This PR introduces a check wherein our `authority` needs to start with a word character (alphanumerics and underline).

I have deliberately kept it wide open beyond this, as I don't want to limit it too far while still closing this gap.

Nota Bene: This does seem to be a regression caused by us simply not having tests for this case when we were doing simplification of URI parsing: https://github.com/polywrap/javascript-client/commit/2906388c169ad46aa55cdb2cb0e924972e28be51